### PR TITLE
[COREV] Fix operand order in cv.setupi instruction

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -84,6 +84,6 @@ let Predicates = [HasExtXCoreVHwlp], hasSideEffects = 0, mayLoad = 0, mayStore =
                                  "cv.setup", "$imm1, $rs1, $imm12">,
                    Sched<[]>;
   def CV_SETUPI  : RVInstHwlp_ii<0b101, (ins cv_uimm1:$imm1, cv_uimm5:$imm5, uimm12:$imm12),
-                              "cv.setupi", "$imm1, $imm5, $imm12">,
+                              "cv.setupi", "$imm1, $imm12, $imm5">,
                 Sched<[]>;
 } // Predicates = [HasExtXCoreVHwlp], hasSideEffects = 0, mayLoad = 0, mayStore = 0

--- a/llvm/test/MC/RISCV/corev/hwlp/fixups.s
+++ b/llvm/test/MC/RISCV/corev/hwlp/fixups.s
@@ -15,6 +15,6 @@ cv.endi 0, foo
 cv.setup 0, zero, foo
 # CHECK-FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_cvpcrel_ui12
 # CHECK-RELOC: R_RISCV_CVPCREL_UI12 foo 0x0
-cv.setupi 0, foo, 0
+cv.setupi 0, 0, foo
 # CHECK-FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_cvpcrel_urs1
 # CHECK-RELOC: R_RISCV_CVPCREL_URS1 foo 0x0

--- a/llvm/test/MC/RISCV/corev/hwlp/setupi-invalid.s
+++ b/llvm/test/MC/RISCV/corev/hwlp/setupi-invalid.s
@@ -1,22 +1,22 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcorevhwlp %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.setupi 1, 31, 0
+cv.setupi 1, 0, 31
 # CHECK-ERROR: immediate must be an even integer in the range [0, 30]
 
-cv.setupi 1, 32, 0
+cv.setupi 1, 0, 32
 # CHECK-ERROR: immediate must be an even integer in the range [0, 30]
 
-cv.setupi 0, -6, 0
+cv.setupi 0, 0, -6
 # CHECK-ERROR: immediate must be an even integer in the range [0, 30]
 
-cv.setupi 0, -7, 0
+cv.setupi 0, 0, -7
 # CHECK-ERROR: immediate must be an even integer in the range [0, 30]
 
-cv.setupi 1, 30, 4096
+cv.setupi 1, 4096, 30
 # CHECK-ERROR: immediate must be an integer in the range [0, 4095]
 
-cv.setupi 1, 30, -10
+cv.setupi 1, -10, 30
 # CHECK-ERROR: immediate must be an integer in the range [0, 4095]
 
 cv.setupi 2, 0, 0
@@ -28,10 +28,10 @@ cv.setupi -1, 0, 0
 cv.setupi s2, 0, 0
 # CHECK-ERROR: immediate must be an integer in the range [0, 1]
 
-cv.setupi 0, s2, 0
+cv.setupi 0, 0, s2
 # CHECK-ERROR: immediate must be an even integer in the range [0, 30]
 
-cv.setupi 0, 0, s2
+cv.setupi 0, s2, 0
 # CHECK-ERROR: immediate must be an integer in the range [0, 4095]
 
 cv.setupi 2

--- a/llvm/test/MC/RISCV/corev/hwlp/setupi.s
+++ b/llvm/test/MC/RISCV/corev/hwlp/setupi.s
@@ -1,34 +1,30 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcorevhwlp -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.setupi 1, 30, 0
-# CHECK-INSTR: cv.setupi 1, 30, 0
+cv.setupi 1, 0, 30
+# CHECK-INSTR: cv.setupi 1, 0, 30
 # CHECK-ENCODING: [0xfb,0x50,0x0f,0x00]
 
-cv.setupi 1, 18, 0
-# CHECK-INSTR: cv.setupi 1, 18, 0
+cv.setupi 1, 0, 18
+# CHECK-INSTR: cv.setupi 1, 0, 18
 # CHECK-ENCODING: [0xfb,0x50,0x09,0x00]
 
 cv.setupi 1, 0, 0
 # CHECK-INSTR: cv.setupi 1, 0, 0
 # CHECK-ENCODING: [0xfb,0x50,0x00,0x00]
 
-cv.setupi 1, 0, 4095
-# CHECK-INSTR: cv.setupi 1, 0, 4095
+cv.setupi 1, 4095, 0
+# CHECK-INSTR: cv.setupi 1, 4095, 0
 # CHECK-ENCODING: [0xfb,0x50,0xf0,0xff]
 
-cv.setupi 1, 0, 1932
-# CHECK-INSTR: cv.setupi 1, 0, 1932
+cv.setupi 1, 1932, 0
+# CHECK-INSTR: cv.setupi 1, 1932, 0
 # CHECK-ENCODING: [0xfb,0x50,0xc0,0x78]
-
-cv.setupi 1, 0, 0
-# CHECK-INSTR: cv.setupi 1, 0, 0
-# CHECK-ENCODING: [0xfb,0x50,0x00,0x00]
 
 cv.setupi 0, 0, 0
 # CHECK-INSTR: cv.setupi 0, 0, 0
 # CHECK-ENCODING: [0x7b,0x50,0x00,0x00]
 
-cv.setupi 0, 0x10, 0x400
-# CHECK-INSTR: cv.setupi 0, 16, 1024
+cv.setupi 0, 0x400, 0x10
+# CHECK-INSTR: cv.setupi 0, 1024, 16
 # CHECK-ENCODING: [0x7b,0x50,0x08,0x40]


### PR DESCRIPTION
This came up in https://github.com/openhwgroup/corev-binutils-gdb/pull/14

r? @jeremybennett 