### PR TITLE
[DNM] Add hardware loop memcpy optimization

### DIFF
--- a/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_target(RISCVCodeGen
   RISCVMergeBaseOffset.cpp
   RISCVRegisterBankInfo.cpp
   RISCVRegisterInfo.cpp
+  RISCVSelectionDAGInfo.cpp
   RISCVSubtarget.cpp
   RISCVTargetMachine.cpp
   RISCVTargetObjectFile.cpp

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -16,6 +16,7 @@
 #include "MCTargetDesc/RISCVTargetStreamer.h"
 #include "RISCV.h"
 #include "RISCVTargetMachine.h"
+#include "RISCVMachineFunctionInfo.h"
 #include "TargetInfo/RISCVTargetInfo.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/CodeGen/AsmPrinter.h"
@@ -68,6 +69,9 @@ public:
   void emitStartOfAsmFile(Module &M) override;
   void emitEndOfAsmFile(Module &M) override;
 
+  void emitBasicBlockStart(const MachineBasicBlock &MBB) override;
+  void emitBasicBlockEnd(const MachineBasicBlock &MBB) override;
+
 private:
   void emitAttributes();
 };
@@ -94,7 +98,14 @@ void RISCVAsmPrinter::emitInstruction(const MachineInstr *MI) {
 
   MCInst TmpInst;
   LowerRISCVMachineInstrToMCInst(MI, TmpInst, *this);
-  EmitToStreamer(*OutStreamer, TmpInst);
+
+  auto *MBB = MI->getParent();
+  auto *RVFI = MI->getMF()->getInfo<RISCVMachineFunctionInfo>();
+
+  if (RVFI->isHwlpBasicBlock(MBB))
+    AsmPrinter::EmitToStreamer(*OutStreamer, TmpInst);
+  else
+    EmitToStreamer(*OutStreamer, TmpInst);
 }
 
 bool RISCVAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
@@ -203,6 +214,29 @@ void RISCVAsmPrinter::emitAttributes() {
   const RISCVSubtarget STI(TT, CPU, /*TuneCPU=*/CPU, FS, /*ABIName=*/"", RTM);
 
   RTS.emitTargetAttributes(STI);
+}
+
+void RISCVAsmPrinter::emitBasicBlockStart(const MachineBasicBlock &MBB) {
+  AsmPrinter::emitBasicBlockStart(MBB);
+
+  auto *RVFI = MF->getInfo<RISCVMachineFunctionInfo>();
+  RISCVTargetStreamer &RTS =
+      static_cast<RISCVTargetStreamer &>(*OutStreamer->getTargetStreamer());
+  if (RVFI->isHwlpBasicBlock(&MBB)) {
+    RTS.emitDirectiveOptionPush();
+    RTS.emitDirectiveOptionNoRVC();
+  }
+}
+
+void RISCVAsmPrinter::emitBasicBlockEnd(const MachineBasicBlock &MBB) {
+  auto *RVFI = MF->getInfo<RISCVMachineFunctionInfo>();
+  RISCVTargetStreamer &RTS =
+      static_cast<RISCVTargetStreamer &>(*OutStreamer->getTargetStreamer());
+  if (RVFI->isHwlpBasicBlock(&MBB)) {
+    RTS.emitDirectiveOptionPop();
+  }
+
+  AsmPrinter::emitBasicBlockEnd(MBB);
 }
 
 // Force static initialization.

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -2650,6 +2650,8 @@ const char *RISCVTargetLowering::getTargetNodeName(unsigned Opcode) const {
     return "RISCVISD::FMV_X_ANYEXTW_RV64";
   case RISCVISD::READ_CYCLE_WIDE:
     return "RISCVISD::READ_CYCLE_WIDE";
+  case RISCVISD::CV_HWLP_MEMCPY:
+    return "RISCVISD::CV_HWLP_MEMCPY";
   }
   return nullptr;
 }

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.h
@@ -51,7 +51,9 @@ enum NodeType : unsigned {
   FMV_X_ANYEXTW_RV64,
   // READ_CYCLE_WIDE - A read of the 64-bit cycle CSR on a 32-bit target
   // (returns (Lo, Hi)). It takes a chain operand.
-  READ_CYCLE_WIDE
+  READ_CYCLE_WIDE,
+  // Operations for the CORE-V extensions
+  CV_HWLP_MEMCPY
 };
 }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -12,6 +12,18 @@
 
 include "RISCVInstrFormatsCOREV.td"
 
+//===----------------------------------------------------------------------===//
+// CORE-V specific DAG nodes.
+//===----------------------------------------------------------------------===//
+
+def corev_hwlp_memcpy_t : SDTypeProfile<0, 3, [SDTCisPtrTy<0>, SDTCisPtrTy<1>, SDTCisInt<2>]>;
+def corev_hwlp_memcpy   : SDNode<"RISCVISD::CV_HWLP_MEMCPY", corev_hwlp_memcpy_t,
+                                 [SDNPMayLoad, SDNPMayStore, SDNPHasChain]>;
+
+//===----------------------------------------------------------------------===//
+// CORE-V specific operands
+//===----------------------------------------------------------------------===//
+
 def CVUImm1AsmOperand : AsmOperandClass {
   let Name = "CVUImm1";
   let RenderMethod = "addImmOperands";
@@ -92,6 +104,12 @@ let Predicates = [HasExtXCoreVHwlp], hasSideEffects = 1, mayLoad = 0, mayStore =
                               "cv.setupi", "$imm1, $imm12, $imm5">,
                 Sched<[]>;
 } // Predicates = [HasExtXCoreVHwlp], hasSideEffects = 1, mayLoad = 0, mayStore = 0
+
+let Predicates = [HasExtXCoreVHwlp], usesCustomInserter = 1, hasSideEffects = 0, mayLoad = 1, mayStore = 1 in {
+  def CV_HWLP_MEMCPY : Pseudo<(outs), (ins GPR:$dest, GPR:$src, uimm12:$count),
+                              [(corev_hwlp_memcpy GPR:$dest, GPR:$src, uimm12:$count)]>;
+
+} // Predicates = [HasExtXCoreVHwlp], usesCustomInserter = 1, hasSideEffects = 0, mayLoad = 1, mayStore = 1
 
 let Predicates = [HasExtXCoreVMac], hasSideEffects = 0, mayLoad = 0, mayStore = 0, Constraints = "$rd = $rd_wb" in {
   // 32x32 bit macs

--- a/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
@@ -1,0 +1,36 @@
+//===-- RISCVSelectionDAGInfo.cpp - RISCV SelectionDAG Info ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the RISCVSelectionDAGInfo class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "RISCVTargetMachine.h"
+#include "RISCVSubtarget.h"
+#include "llvm/CodeGen/SelectionDAGNodes.h"
+using namespace llvm;
+
+#define DEBUG_TYPE "riscv-selectiondag-info"
+
+SDValue RISCVSelectionDAGInfo::EmitTargetCodeForMemcpy(
+    SelectionDAG &DAG, const SDLoc &dl, SDValue Chain, SDValue Dst, SDValue Src,
+    SDValue Size, Align Alignment, bool isVolatile, bool AlwaysInline,
+    MachinePointerInfo DstPtrInfo, MachinePointerInfo SrcPtrInfo) const {
+  // If no hardware loops are available, use the default lowering
+  const RISCVSubtarget &Subtarget = DAG.getMachineFunction().getSubtarget<RISCVSubtarget>();
+  if (!Subtarget.hasExtXCoreVHwlp())
+    return SDValue();
+
+  ConstantSDNode *CN = dyn_cast<ConstantSDNode>(Size);
+  if (!CN || CN->getZExtValue() > 0xfff)
+    return SDValue();
+
+  SDValue ConstSize = DAG.getConstant(CN->getZExtValue(), dl, Src.getValueType());
+
+  return DAG.getNode(RISCVISD::CV_HWLP_MEMCPY, dl, MVT::Other, Chain, Dst, Src, ConstSize);
+}

--- a/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.h
@@ -1,0 +1,32 @@
+//===-- RISCVSelectionDAGInfo.h - RISCV SelectionDAG Info -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the RISCV subclass for SelectionDAGTargetInfo.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_RISCV_RISCVSELECTIONDAGINFO_H
+#define LLVM_LIB_TARGET_RISCV_RISCVSELECTIONDAGINFO_H
+
+#include "llvm/CodeGen/SelectionDAGTargetInfo.h"
+
+namespace llvm {
+
+class RISCVSelectionDAGInfo : public SelectionDAGTargetInfo {
+public:
+  SDValue EmitTargetCodeForMemcpy(SelectionDAG &DAG, const SDLoc &dl,
+                                  SDValue Chain, SDValue Op1, SDValue Op2,
+                                  SDValue Op3, Align Alignment, bool isVolatile,
+                                  bool AlwaysInline,
+                                  MachinePointerInfo DstPtrInfo,
+                                  MachinePointerInfo SrcPtrInfo) const override;
+};
+
+} // namespace llvm
+
+#endif

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -16,6 +16,7 @@
 #include "RISCVFrameLowering.h"
 #include "RISCVISelLowering.h"
 #include "RISCVInstrInfo.h"
+#include "RISCVSelectionDAGInfo.h"
 #include "Utils/RISCVBaseInfo.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
@@ -71,7 +72,7 @@ class RISCVSubtarget : public RISCVGenSubtargetInfo {
   RISCVInstrInfo InstrInfo;
   RISCVRegisterInfo RegInfo;
   RISCVTargetLowering TLInfo;
-  SelectionDAGTargetInfo TSInfo;
+  RISCVSelectionDAGInfo TSInfo;
 
   /// Initializes using the passed in CPU and feature strings so that we can
   /// use initializer lists for subtarget initialization.

--- a/llvm/test/CodeGen/RISCV/memcpy-hwlp.ll
+++ b/llvm/test/CodeGen/RISCV/memcpy-hwlp.ll
@@ -1,0 +1,119 @@
+; RUN: llc < %s -mtriple=riscv32 -mattr=xcorev | FileCheck %s
+; RUN: llc < %s -mtriple=riscv32 | FileCheck %s -check-prefix=CHECK-NOHWLP
+; RUN: llc < %s -mtriple=riscv32 -mattr=xcorev,c --show-mc-encoding \
+; RUN:   | FileCheck %s -check-prefix=CHECK-ENCODING
+
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8 *nocapture, i8 *nocapture, i32, i1) nounwind
+
+define void @with_hwlp_unaligned(i8* %dest, i8* %src) {
+  ; CHECK-LABEL: with_hwlp_unaligned:
+  ; CHECK: .option push
+  ; CHECK-NEXT: .option norvc
+  ; CHECK-NEXT: cv.setupi 0, 16, .LBB0_2
+  ; CHECK-NEXT: lb a2, 0(a1)
+  ; CHECK-NEXT: sb a2, 0(a0)
+  ; CHECK-NEXT: addi a1, a1, 1
+  ; CHECK-NEXT: addi a0, a0, 1
+  ; CHECK-NEXT: .option pop
+  ; CHECK-NEXT: .LBB0_2
+  ; CHECK-NEXT: .option push
+  ; CHECK-NEXT: .option norvc
+  ; CHECK-NEXT: nop
+  ; CHECK-NEXT: .option pop
+  ; CHECK-NEXT: .LBB0_3
+  ; CHECK-NEXT: ret
+  ; CHECK-ENCODING: [0x03,0x86,0x05,0x00]
+  ; CHECK-ENCODING: [0x23,0x00,0xc5,0x00]
+  ; CHECK-ENCODING: [0x93,0x85,0x15,0x00]
+  ; CHECK-ENCODING: [0x13,0x05,0x15,0x00]
+  ; CHECK-ENCODING: [0x13,0x00,0x00,0x00]
+  ; CHECK-ENCODING: [0x82,0x80]
+  ; CHECK-NOHWLP: call memcpy
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %dest, i8* %src, i32 16, i1 false)
+  ret void
+}
+
+define void @with_hwlp(i8* %dest, i8* %src) {
+  ; CHECK-LABEL: with_hwlp:
+  ; CHECK: .option push
+  ; CHECK-NEXT: .option norvc
+  ; CHECK-NEXT: cv.setupi 0, 33, .LBB1_2
+  ; CHECK-NEXT: lb a2, 0(a1)
+  ; CHECK-NEXT: sb a2, 0(a0)
+  ; CHECK-NEXT: addi a1, a1, 1
+  ; CHECK-NEXT: addi a0, a0, 1
+  ; CHECK-NEXT: .option pop
+  ; CHECK-NEXT: .LBB1_2
+  ; CHECK-NEXT: .option push
+  ; CHECK-NEXT: .option norvc
+  ; CHECK-NEXT: nop
+  ; CHECK-NEXT: .option pop
+  ; CHECK-NEXT: .LBB1_3
+  ; CHECK-NEXT: ret
+  ; CHECK-ENCODING: [0x03,0x86,0x05,0x00]
+  ; CHECK-ENCODING: [0x23,0x00,0xc5,0x00]
+  ; CHECK-ENCODING: [0x93,0x85,0x15,0x00]
+  ; CHECK-ENCODING: [0x13,0x05,0x15,0x00]
+  ; CHECK-ENCODING: [0x13,0x00,0x00,0x00]
+  ; CHECK-ENCODING: [0x82,0x80]
+  ; CHECK-NOHWLP: call memcpy
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 4 %dest, i8* align 4 %src, i32 33, i1 false)
+  ret void
+}
+
+define void @with_hwlp_max_count(i8* %dest, i8* %src) {
+  ; CHECK-LABEL: with_hwlp_max_count:
+  ; CHECK: .option push
+  ; CHECK-NEXT: .option norvc
+  ; CHECK-NEXT: cv.setupi 0, 4095, .LBB2_2
+  ; CHECK-NEXT: lb a2, 0(a1)
+  ; CHECK-NEXT: sb a2, 0(a0)
+  ; CHECK-NEXT: addi a1, a1, 1
+  ; CHECK-NEXT: addi a0, a0, 1
+  ; CHECK-NEXT: .option pop
+  ; CHECK-NEXT: .LBB2_2
+  ; CHECK-NEXT: .option push
+  ; CHECK-NEXT: .option norvc
+  ; CHECK-NEXT: nop
+  ; CHECK-NEXT: .option pop
+  ; CHECK-NEXT: .LBB2_3
+  ; CHECK-NEXT: ret
+  ; CHECK-ENCODING: [0x03,0x86,0x05,0x00]
+  ; CHECK-ENCODING: [0x23,0x00,0xc5,0x00]
+  ; CHECK-ENCODING: [0x93,0x85,0x15,0x00]
+  ; CHECK-ENCODING: [0x13,0x05,0x15,0x00]
+  ; CHECK-ENCODING: [0x13,0x00,0x00,0x00]
+  ; CHECK-ENCODING: [0x82,0x80]
+  ; CHECK-NOHWLP: call memcpy
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 4 %dest, i8* align 4 %src, i32 4095, i1 false)
+  ret void
+}
+
+define void @with_load_store(i8* %Dest, i8* %Src) {
+  ; CHECK-LABEL: with_load_store:
+  ; CHECK: lw a2, 28(a1)
+  ; CHECK-NEXT: sw a2, 28(a0)
+  ; CHECK-NEXT: lw a2, 24(a1)
+  ; CHECK-NEXT: sw a2, 24(a0)
+  ; CHECK-NEXT: lw a2, 20(a1)
+  ; CHECK-NEXT: sw a2, 20(a0)
+  ; CHECK-NEXT: lw a2, 16(a1)
+  ; CHECK-NEXT: sw a2, 16(a0)
+  ; CHECK-NEXT: lw a2, 12(a1)
+  ; CHECK-NEXT: sw a2, 12(a0)
+  ; CHECK-NEXT: lw a2, 8(a1)
+  ; CHECK-NEXT: sw a2, 8(a0)
+  ; CHECK-NEXT: lw a2, 4(a1)
+  ; CHECK-NEXT: sw a2, 4(a0)
+  ; CHECK-NEXT: lw a1, 0(a1)
+  ; CHECK-NEXT: sw a1, 0(a0)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 4 %Dest, i8* align 4 %Src, i32 32, i1 false)
+  ret void
+}
+
+define void @without_hwlp_max_count_p1(i8* %dest, i8* %src) {
+  ; CHECK-LABEL: without_hwlp_max_count_p1:
+  ; CHECK: call memcpy
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 4 %dest, i8* align 4 %src, i32 4096, i1 false)
+  ret void
+}


### PR DESCRIPTION
DNM: This PR is awaiting testing on the hardware before it can get merged.

TODO:
- [ ] There are now more contraints on HWLPs than just "no compressed instructions". Those have to be addressed before merging/testing this.
- [ ] Fix bug, when compiled with `-Os`:
    ```c
    typedef unsigned char uint8_t;

    struct S {
        uint8_t b[N];
    };

    extern struct S a, b;

    uint8_t f (int i)
    {
        if(i)
            a = b;

        return a.b[0];
    }
    ```
    When compiled with `-Os` this tests moves the dummy basic block containing the `nop` instruction.

r? @simonpcook 