### PR TITLE
[COREV][clang] Add information about the xcorev extensions

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -129,6 +129,12 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
 
   if (HasB)
     Builder.defineMacro("__riscv_bitmanip");
+
+  if (HasXCoreV)
+    Builder.defineMacro("__riscv_xcorev");
+    Builder.defineMacro("__riscv_xcorevhwlp");
+  if (HasXCoreVHwlp)
+    Builder.defineMacro("__riscv_xcorevhwlp");
 }
 
 /// Return true if has this feature, need to sync with handleTargetFeatures.
@@ -144,6 +150,8 @@ bool RISCVTargetInfo::hasFeature(StringRef Feature) const {
       .Case("d", HasD)
       .Case("c", HasC)
       .Case("experimental-b", HasB)
+      .Case("xcorev", HasXCoreV)
+      .Case("xcorevhwlp", HasXCoreVHwlp)
       .Default(false);
 }
 
@@ -163,6 +171,10 @@ bool RISCVTargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasC = true;
     else if (Feature == "+experimental-b")
       HasB = true;
+    else if (Feature == "+xcorev")
+      HasXCoreV = true;
+    else if (Feature == "+xcorevhwlp")
+      HasXCoreVHwlp = true;
   }
 
   return true;

--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -31,6 +31,8 @@ protected:
   bool HasD;
   bool HasC;
   bool HasB;
+  bool HasXCoreV;
+  bool HasXCoreVHwlp;
 
 public:
   RISCVTargetInfo(const llvm::Triple &Triple, const TargetOptions &)

--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -67,12 +67,18 @@ isExperimentalExtension(StringRef Ext) {
   return None;
 }
 
+static bool isSupportedNonStandardUserLevelExtension(StringRef Ext) {
+    return Ext == "xcorev" || Ext == "xcorevhwlp";
+}
+
 static bool isSupportedExtension(StringRef Ext) {
   // LLVM supports "z" extensions which are marked as experimental.
   if (isExperimentalExtension(Ext))
     return true;
+  if (isSupportedNonStandardUserLevelExtension(Ext))
+    return true;
 
-  // LLVM does not support "sx", "s" nor "x" extensions.
+  // LLVM does not support other "sx", "s", or "x" extensions.
   return false;
 }
 

--- a/clang/test/Driver/riscv-arch.c
+++ b/clang/test/Driver/riscv-arch.c
@@ -383,3 +383,15 @@
 // RUN: %clang -target riscv32-unknown-elf -march=rv32iv0p9 -menable-experimental-extensions -### %s -c 2>&1 | \
 // RUN:   FileCheck -check-prefix=RV32-EXPERIMENTAL-V-GOODVERS %s
 // RV32-EXPERIMENTAL-V-GOODVERS: "-target-feature" "+experimental-v"
+
+// RUN: %clang -target riscv32-unknown-elf -march=rv32ixcorevunsupported -### %s -c 2>&1 | \
+// RUN:   FileCheck -check-prefix=RV32-XCOREV-UNKNOWN %s
+// RV32-XCOREV-UNKNOWN: unsupported non-standard user-level extension 'xcorevunsupported'
+
+// RUN: %clang -target riscv32-unknown-elf -march=rv32ixcorev -### %s -c 2>&1 | \
+// RUN:   FileCheck -check-prefix=RV32-XCOREV %s
+// RV32-XCOREV: "-target-feature" "+xcorev"
+
+// RUN: %clang -target riscv32-unknown-elf -march=rv32ixcorevhwlp -### %s -c 2>&1 | \
+// RUN:   FileCheck -check-prefix=RV32-XCOREVHWLP %s
+// RV32-XCOREVHWLP: "-target-feature" "+xcorevhwlp"


### PR DESCRIPTION
This commit adds the `+xcorev*` target-feature flags to clang.

Merging this just now might not make much sense, since there aren't any builtins or similar that can be used. It mike make sense to hold off on this until at least MAC builtins are implemented.