### PR TITLE
[COREV] Cleanup of the CORE-V HW Loop instructions

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
@@ -467,11 +467,15 @@ unsigned RISCVMCCodeEmitter::getImmOpValue(const MCInst &MI, unsigned OpNo,
       FixupKind = RISCV::fixup_riscv_rvc_jump;
     } else if (MIFrm == RISCVII::InstFormatCB) {
       FixupKind = RISCV::fixup_riscv_rvc_branch;
-    } else if (MIFrm == RISCVII::InstFormatCVHWLP) {
-      if (OpNo == 1 && MI.getNumOperands() == 3) {
-        // This is the cv.setupi instruction and therefore requires the 5 bit
-        // relocation.
-        FixupKind = RISCV::fixup_riscv_cvpcrel_urs1;
+    } else if (MIFrm == RISCVII::InstFormatCVHwlp) {
+      if (MI.getNumOperands() == 3) {
+        auto &MOCount = MI.getOperand(1);
+        if (MOCount.isReg())
+          FixupKind = RISCV::fixup_riscv_cvpcrel_ui12;
+        else
+          // This is the cv.setupi instruction and therefore requires the 5 bit
+          // relocation.
+          FixupKind = RISCV::fixup_riscv_cvpcrel_urs1;
       } else {
         FixupKind = RISCV::fixup_riscv_cvpcrel_ui12;
       }

--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -48,7 +48,7 @@ def InstFormatCA     : InstFormat<14>;
 def InstFormatCB     : InstFormat<15>;
 def InstFormatCJ     : InstFormat<16>;
 def InstFormatOther  : InstFormat<17>;
-def InstFormatCVHWLP : InstFormat<18>;
+def InstFormatCVHwlp : InstFormat<18>;
 
 class RISCVVConstraint<bits<4> val> {
   bits<4> Value = val;

--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsCOREV.td
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 class RVInstHwlp_i<bits<3> funct3, dag ins, string opcodestr, string argstr>
-    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHWLP> {
+    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHwlp> {
   bits<12> imm12;
   bits<1> imm1;
 
@@ -26,7 +26,7 @@ class RVInstHwlp_i<bits<3> funct3, dag ins, string opcodestr, string argstr>
 }
 
 class RVInstHwlp_r<bits<3> funct3, dag ins, string opcodestr, string argstr>
-    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHWLP> {
+    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHwlp> {
   bits<5> rs1;
   bits<1> imm1;
 
@@ -39,7 +39,7 @@ class RVInstHwlp_r<bits<3> funct3, dag ins, string opcodestr, string argstr>
 }
 
 class RVInstHwlp_ri<bits<3> funct3, dag ins, string opcodestr, string argstr>
-    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHWLP> {
+    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHwlp> {
   bits<12> imm12;
   bits<5> rs1;
   bits<1> imm1;
@@ -53,7 +53,7 @@ class RVInstHwlp_ri<bits<3> funct3, dag ins, string opcodestr, string argstr>
 }
 
 class RVInstHwlp_ii<bits<3> funct3, dag ins, string opcodestr, string argstr>
-    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHWLP> {
+    : RVInst<(outs), ins, opcodestr, argstr, [], InstFormatCVHwlp> {
   bits<12> imm12;
   bits<5> imm5;
   bits<1> imm1;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -67,7 +67,11 @@ def cv_uimm12 : Operand<XLenVT>,
   let OperandNamespace = "RISCVOp";
 }
 
-let Predicates = [HasExtXCoreVHwlp], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
+//===----------------------------------------------------------------------===//
+// CORE-V specific instructions
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasExtXCoreVHwlp], hasSideEffects = 1, mayLoad = 0, mayStore = 0 in {
   def CV_STARTI  : RVInstHwlp_i<0b000, (ins cv_uimm1:$imm1, cv_uimm12:$imm12),
                                 "cv.starti", "$imm1, $imm12">,
                    Sched<[]>;
@@ -83,7 +87,7 @@ let Predicates = [HasExtXCoreVHwlp], hasSideEffects = 0, mayLoad = 0, mayStore =
   def CV_SETUP   : RVInstHwlp_ri<0b100, (ins cv_uimm1:$imm1, GPR:$rs1, cv_uimm12:$imm12),
                                  "cv.setup", "$imm1, $rs1, $imm12">,
                    Sched<[]>;
-  def CV_SETUPI  : RVInstHwlp_ii<0b101, (ins cv_uimm1:$imm1, cv_uimm5:$imm5, uimm12:$imm12),
+  def CV_SETUPI  : RVInstHwlp_ii<0b101, (ins cv_uimm1:$imm1, uimm12:$imm12, cv_uimm5:$imm5),
                               "cv.setupi", "$imm1, $imm12, $imm5">,
                 Sched<[]>;
-} // Predicates = [HasExtXCoreVHwlp], hasSideEffects = 0, mayLoad = 0, mayStore = 0
+} // Predicates = [HasExtXCoreVHwlp], hasSideEffects = 1, mayLoad = 0, mayStore = 0

--- a/llvm/lib/Target/RISCV/Utils/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/Utils/RISCVBaseInfo.h
@@ -43,7 +43,7 @@ enum {
   InstFormatCB = 15,
   InstFormatCJ = 16,
   InstFormatOther = 17,
-  InstFormatCVHWLP = 18,
+  InstFormatCVHwlp = 18,
 
   InstFormatMask = 31,
 };


### PR DESCRIPTION
This PR does 3 things:

- Rename InstFormatCVHWLP -> InstFormatCVHwlp for consistency
  Everywhere else Hardware Loop is abbreviated with Hwlp, except for the
  `InstFormat`.

- Fix internal order of CV_SETUPI instruction
  The order of the operands of this instruction in the asm parser was
  fixed before. This PR cleans this up internally.

- Mark HW loop instruction with `HasSideEffects = 1`
  HW loop instruction don't write anything. Without that flag they just
  get optimized out by LLVM passes.