### PR TITLE
[COREV] Fix fallthrough warning

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -190,7 +190,9 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
       case MVT::i32:
         if (simm12) Opcode = RISCV::CV_LW_ri_inc;
         else        Opcode = RISCV::CV_LW_rr_inc;
-      default: break;
+        break;
+      default:
+        break;
     }
     if (!Opcode) break;
 


### PR DESCRIPTION
This was introduced in https://github.com/openhwgroup/corev-llvm-project/pull/13, which I missed during review.