### PR TITLE
[COREV] Add more tests for ALU and load/store instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -243,7 +243,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SIGN_EXTEND_INREG, MVT::i8, Legal);
     setOperationAction(ISD::SIGN_EXTEND_INREG, MVT::i16, Legal);
   }
-  
+
   if (Subtarget.hasExtXCoreVMem()) {
     setIndexedLoadAction(ISD::POST_INC, MVT::i8, Legal);
     setIndexedLoadAction(ISD::POST_INC, MVT::i16, Legal);

--- a/llvm/test/MC/RISCV/corev/alu-all-extensions.s
+++ b/llvm/test/MC/RISCV/corev/alu-all-extensions.s
@@ -1,0 +1,139 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcorev -show-encoding %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-INSTR,CHECK-ENCODING
+
+# ALU instructions
+
+cv.abs t0, t1
+# CHECK-INSTR: cv.abs t0, t1
+# CHECK-ENCODING: [0xb3,0x02,0x03,0x04]
+
+cv.slet t0, t1, t2
+# CHECK-INSTR: cv.slet t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x22,0x73,0x04]
+
+cv.sletu t0, t1, t2
+# CHECK-INSTR: cv.sletu t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x32,0x73,0x04]
+
+cv.min t0, t1, t2
+# CHECK-INSTR: cv.min t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x42,0x73,0x04]
+
+cv.minu t0, t1, t2
+# CHECK-INSTR: cv.minu t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x52,0x73,0x04]
+
+cv.max t0, t1, t2
+# CHECK-INSTR: cv.max t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x62,0x73,0x04]
+
+cv.maxu t0, t1, t2
+# CHECK-INSTR: cv.maxu t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x72,0x73,0x04]
+
+cv.exths t0, t1
+# CHECK-INSTR: cv.exths t0, t1
+# CHECK-ENCODING: [0xb3,0x42,0x03,0x10]
+
+cv.exthz t0, t1
+# CHECK-INSTR: cv.exthz t0, t1
+# CHECK-ENCODING: [0xb3,0x52,0x03,0x10]
+
+cv.extbs t0, t1
+# CHECK-INSTR: cv.extbs t0, t1
+# CHECK-ENCODING: [0xb3,0x62,0x03,0x10]
+
+cv.extbz t0, t1
+# CHECK-INSTR: cv.extbz t0, t1
+# CHECK-ENCODING: [0xb3,0x72,0x03,0x10]
+
+
+cv.clip t0, t1, 5
+# CHECK-INSTR: cv.clip t0, t1, 5
+# CHECK-ENCODING: [0xb3,0x12,0x53,0x14]
+
+cv.clipu t0, t1, 5
+# CHECK-INSTR: cv.clipu t0, t1, 5
+# CHECK-ENCODING: [0xb3,0x22,0x53,0x14]
+
+cv.clipr t0, t1, t2
+# CHECK-INSTR: cv.clipr t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x52,0x73,0x14]
+
+cv.clipur t0, t1, t2
+# CHECK-INSTR: cv.clipur t0, t1, t2
+# CHECK-ENCODING: [0xb3,0x62,0x73,0x14]
+
+
+cv.addn t0, t1, t2, 5
+# CHECK-INSTR: cv.addn t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x22,0x73,0x0a]
+
+cv.addun t0, t1, t2, 5
+# CHECK-INSTR: cv.addun t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x22,0x73,0x8a]
+
+cv.addrn t0, t1, t2, 5
+# CHECK-INSTR: cv.addrn t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x62,0x73,0x0a]
+
+cv.addurn t0, t1, t2, 5
+# CHECK-INSTR: cv.addurn t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x62,0x73,0x8a]
+
+cv.subn t0, t1, t2, 5
+# CHECK-INSTR: cv.subn t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x32,0x73,0x0a]
+
+cv.subun t0, t1, t2, 5
+# CHECK-INSTR: cv.subun t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x32,0x73,0x8a]
+
+cv.subrn t0, t1, t2, 5
+# CHECK-INSTR: cv.subrn t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x72,0x73,0x0a]
+
+cv.suburn t0, t1, t2, 5
+# CHECK-INSTR: cv.suburn t0, t1, t2, 5
+# CHECK-ENCODING: [0xdb,0x72,0x73,0x8a]
+
+cv.addnr t0, t1, t2
+# CHECK-INSTR: cv.addnr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x22,0x73,0x40]
+
+cv.addunr t0, t1, t2
+# CHECK-INSTR: cv.addunr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x22,0x73,0xc0]
+
+cv.addrnr t0, t1, t2
+# CHECK-INSTR: cv.addrnr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x62,0x73,0x40]
+
+cv.addurnr t0, t1, t2
+# CHECK-INSTR: cv.addurnr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x62,0x73,0xc0]
+
+cv.subnr t0, t1, t2
+# CHECK-INSTR: cv.subnr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x32,0x73,0x40]
+
+cv.subunr t0, t1, t2
+# CHECK-INSTR: cv.subunr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x32,0x73,0xc0]
+
+cv.subrnr t0, t1, t2
+# CHECK-INSTR: cv.subrnr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x72,0x73,0x40]
+
+cv.suburnr t0, t1, t2
+# CHECK-INSTR: cv.suburnr t0, t1, t2
+# CHECK-ENCODING: [0xdb,0x72,0x73,0xc0]
+
+
+cv.beqimm t0, 0, 0
+# CHECK-INSTR: cv.beqimm t0, 0, 0
+# CHECK-ENCODING: [0x63,0xa0,0x02,0x00]
+
+cv.bneimm t0, 0, 0
+# CHECK-INSTR: cv.bneimm t0, 0, 0
+# CHECK-ENCODING: [0x63,0xb0,0x02,0x00]

--- a/llvm/test/MC/RISCV/corev/alu/invalid.s
+++ b/llvm/test/MC/RISCV/corev/alu/invalid.s
@@ -1,0 +1,106 @@
+# RUN: not llvm-mc -triple=riscv32 %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+
+# ALU instructions
+
+cv.abs t0, t1
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.slet t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.sletu t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.min t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.minu t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.max t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.maxu t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.exths t0, t1
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.exthz t0, t1
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.extbs t0, t1
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.extbz t0, t1
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+
+cv.clip t0, t1, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.clipu t0, t1, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.clipr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.clipur t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+
+cv.addn t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.addun t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.addrn t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.addurn t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.subn t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.subun t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.subrn t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.suburn t0, t1, t2, 5
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.addnr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.addunr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.addrnr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.addurnr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.subnr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.subunr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.subrnr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.suburnr t0, t1, t2
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+
+cv.beqimm t0, 0, 0
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)
+
+cv.bneimm t0, 0, 0
+# CHECK-ERROR: instruction requires the following: 'Xcorevalu' (ALU Operations)

--- a/llvm/test/MC/RISCV/corev/mem-all-extensions.s
+++ b/llvm/test/MC/RISCV/corev/mem-all-extensions.s
@@ -1,0 +1,107 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcorev -show-encoding %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-INSTR,CHECK-ENCODING
+
+# Load instructions
+
+cv.lb t0, 0(t1!)
+# CHECK-INSTR: cv.lb t0, 0(t1!)
+# CHECK-ENCODING: [0x8b,0x02,0x03,0x00]
+
+cv.lbu t0, 0(t1!)
+# CHECK-INSTR: cv.lbu t0, 0(t1!)
+# CHECK-ENCODING: [0x8b,0x42,0x03,0x00]
+
+cv.lh t0, 0(t1!)
+# CHECK-INSTR: cv.lh t0, 0(t1!)
+# CHECK-ENCODING: [0x8b,0x12,0x03,0x00]
+
+cv.lhu t0, 0(t1!)
+# CHECK-INSTR: cv.lhu t0, 0(t1!)
+# CHECK-ENCODING: [0x8b,0x52,0x03,0x00]
+
+cv.lw t0, 0(t1!)
+# CHECK-INSTR: cv.lw t0, 0(t1!)
+# CHECK-ENCODING: [0x8b,0x22,0x03,0x00]
+
+
+cv.lb t0, t2(t1!)
+# CHECK-INSTR: cv.lb t0, t2(t1!)
+# CHECK-ENCODING: [0x8b,0x72,0x73,0x00]
+
+cv.lbu t0, t2(t1!)
+# CHECK-INSTR: cv.lbu t0, t2(t1!)
+# CHECK-ENCODING: [0x8b,0x72,0x73,0x40]
+
+cv.lh t0, t2(t1!)
+# CHECK-INSTR: cv.lh t0, t2(t1!)
+# CHECK-ENCODING: [0x8b,0x72,0x73,0x10]
+
+cv.lhu t0, t2(t1!)
+# CHECK-INSTR: cv.lhu t0, t2(t1!)
+# CHECK-ENCODING: [0x8b,0x72,0x73,0x50]
+
+cv.lw t0, t2(t1!)
+# CHECK-INSTR: cv.lw t0, t2(t1!)
+# CHECK-ENCODING: [0x8b,0x72,0x73,0x20]
+
+
+cv.lb t0, t2(t1)
+# CHECK-INSTR: cv.lb t0, t2(t1)
+# CHECK-ENCODING: [0x83,0x72,0x73,0x00]
+
+cv.lbu t0, t2(t1)
+# CHECK-INSTR: cv.lbu t0, t2(t1)
+# CHECK-ENCODING: [0x83,0x72,0x73,0x40]
+
+cv.lh t0, t2(t1)
+# CHECK-INSTR: cv.lh t0, t2(t1)
+# CHECK-ENCODING: [0x83,0x72,0x73,0x10]
+
+cv.lhu t0, t2(t1)
+# CHECK-INSTR: cv.lhu t0, t2(t1)
+# CHECK-ENCODING: [0x83,0x72,0x73,0x50]
+
+cv.lw t0, t2(t1)
+# CHECK-INSTR: cv.lw t0, t2(t1)
+# CHECK-ENCODING: [0x83,0x72,0x73,0x20]
+
+
+# Store instructions
+
+cv.sb t0, 0(t1!)
+# CHECK-INSTR: cv.sb t0, 0(t1!)
+# CHECK-ENCODING: [0x2b,0x00,0x53,0x00]
+
+cv.sh t0, 0(t1!)
+# CHECK-INSTR: cv.sh t0, 0(t1!)
+# CHECK-ENCODING: [0x2b,0x10,0x53,0x00]
+
+cv.sw t0, 0(t1!)
+# CHECK-INSTR: cv.sw t0, 0(t1!)
+# CHECK-ENCODING: [0x2b,0x20,0x53,0x00]
+
+
+cv.sb t0, t2(t1!)
+# CHECK-INSTR: cv.sb t0, t2(t1!)
+# CHECK-ENCODING: [0xab,0x43,0x53,0x00]
+
+cv.sh t0, t2(t1!)
+# CHECK-INSTR: cv.sh t0, t2(t1!)
+# CHECK-ENCODING: [0xab,0x53,0x53,0x00]
+
+cv.sw t0, t2(t1!)
+# CHECK-INSTR: cv.sw t0, t2(t1!)
+# CHECK-ENCODING: [0xab,0x63,0x53,0x00]
+
+
+cv.sb t0, t2(t1)
+# CHECK-INSTR: cv.sb t0, t2(t1)
+# CHECK-ENCODING: [0xa3,0x43,0x53,0x00]
+
+cv.sh t0, t2(t1)
+# CHECK-INSTR: cv.sh t0, t2(t1)
+# CHECK-ENCODING: [0xa3,0x53,0x53,0x00]
+
+cv.sw t0, t2(t1)
+# CHECK-INSTR: cv.sw t0, t2(t1)
+# CHECK-ENCODING: [0xa3,0x63,0x53,0x00]

--- a/llvm/test/MC/RISCV/corev/mem/invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/invalid.s
@@ -1,0 +1,83 @@
+# RUN: not llvm-mc -triple=riscv32 %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+
+# Load instructions
+
+cv.lb t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+cv.lbu t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+cv.lh t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+cv.lhu t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+cv.lw t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+
+cv.lb t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+cv.lbu t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+cv.lh t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+cv.lhu t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+cv.lw t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+
+cv.lb t0, t2(t1)
+# CHECK-ERROR: unexpected token
+
+cv.lbu t0, t2(t1)
+# CHECK-ERROR: unexpected token
+
+cv.lh t0, t2(t1)
+# CHECK-ERROR: unexpected token
+
+cv.lhu t0, t2(t1)
+# CHECK-ERROR: unexpected token
+
+cv.lw t0, t2(t1)
+# CHECK-ERROR: unexpected token
+
+
+# Store instructions
+
+cv.sb t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+cv.sh t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+cv.sw t0, 0(t1!)
+# CHECK-ERROR: expected ')'
+
+
+cv.sb t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+cv.sh t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+cv.sw t0, t2(t1!)
+# CHECK-ERROR: unexpected token
+
+
+cv.sb t0, t2(t1)
+# CHECK-ERROR: unexpected token
+
+cv.sh t0, t2(t1)
+# CHECK-ERROR: unexpected token
+
+cv.sw t0, t2(t1)
+# CHECK-ERROR: unexpected token


### PR DESCRIPTION
These tests make sure that the instructions are not available without the `xcorevalu`/`xcorevmem` features and that they are also available with the `xcorev` feature.