### PR TITLE
[COREV] Fix generation for clipu from betweenu pattern

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -436,8 +436,8 @@ def between : PatFrags<(ops node:$lowerBound, node:$upperBound, node:$value),
                         (smax (smin node:$value, node:$upperBound), node:$lowerBound)]>;
 
 def betweenu : PatFrags<(ops node:$upperBound, node:$value),
-                        [(umin (umax node:$value, 0), node:$upperBound),
-                         (umax (umin node:$value, node:$upperBound), 0)]>;
+                        [(smin (smax node:$value, 0), node:$upperBound),
+                         (smax (smin node:$value, node:$upperBound), 0)]>;
 
 
 def clip : PatFrag<(ops node:$upperBound, node:$value),

--- a/llvm/test/CodeGen/RISCV/corev/alu.ll
+++ b/llvm/test/CodeGen/RISCV/corev/alu.ll
@@ -137,8 +137,8 @@ define i32 @clipu(i32 %a) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    cv.clipu a0, a0, 5
 ; CHECK-NEXT:    ret
-  %1 = call i32 @llvm.umax.i32(i32 %a, i32 0)
-  %2 = call i32 @llvm.umin.i32(i32 %1, i32 15)
+  %1 = call i32 @llvm.smax.i32(i32 %a, i32 0)
+  %2 = call i32 @llvm.smin.i32(i32 %1, i32 15)
   ret i32 %2
 }
 
@@ -147,8 +147,8 @@ define i32 @clipur(i32 %a, i32 %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    cv.clipur a0, a0, a1
 ; CHECK-NEXT:    ret
-  %1 = call i32 @llvm.umax.i32(i32 %a, i32 0)
-  %2 = call i32 @llvm.umin.i32(i32 %1, i32 %b)
+  %1 = call i32 @llvm.smax.i32(i32 %a, i32 0)
+  %2 = call i32 @llvm.smin.i32(i32 %1, i32 %b)
   ret i32 %2
 }
 


### PR DESCRIPTION
It appears the definition for the betweenu pattern is erroneous as the use of an unsigned appears to refer to how the output appears and not how the inputs are treated. This causes further problems as the tests for clipu expect this erroneous behaviour.

This patch resolves this issue within the definition of the betweenu pattern and the tests so that generation of the clipu instruction can occur and is tested for successfully. This fixes a failing test.