### PR TITLE
[RISCV] Add xcvsimd option

### DIFF
--- a/clang/test/Driver/riscv-arch.c
+++ b/clang/test/Driver/riscv-arch.c
@@ -583,3 +583,12 @@
 // RUN: %clang -target riscv32-unknown-elf -march=rv32i_zmmul1p0 -### %s \
 // RUN: -fsyntax-only 2>&1 | FileCheck -check-prefix=RV32-ZMMUL-GOODVERS %s
 // RV32-ZMMUL-GOODVERS: "-target-feature" "+zmmul"
+
+// RUN: %clang -target riscv32-unknown-elf -march=rv32i_xcvsimd1p0 -### %s \
+// RUN: -fsyntax-only 2>&1 | FileCheck -check-prefix=RV32-XCVSIMD-GOODVERS %s
+// RV32-XCVSIMD-GOODVERS: "-target-feature" "+xcvsimd"
+
+// RUN: %clang -target riscv32-unknown-elf -march=rv32i_xcvsimd2p0 -### %s \
+// RUN: -fsyntax-only 2>&1 | FileCheck -check-prefix=RV32-XCVSIMD-BADVERS %s
+// RV32-XCVSIMD-BADVERS: error: invalid arch name 'rv32i_xcvsimd2p0'
+// RV32-XCVSIMD-BADVERS: unsupported version number 2.0 for extension

--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -103,6 +103,8 @@ static const RISCVSupportedExtension SupportedExtensions[] = {
     {"zicbop", RISCVExtensionVersion{1, 0}},
 
     {"svnapot", RISCVExtensionVersion{1, 0}},
+
+    {"xcvsimd", RISCVExtensionVersion{1, 0}},
 };
 
 static const RISCVSupportedExtension SupportedExperimentalExtensions[] = {


### PR DESCRIPTION
Split the code for adding option `xcvsimd` here as in https://github.com/openhwgroup/corev-llvm-project/pull/32#discussion_r1116707247.
