### PR TITLE
[RISCV] Fix signedness of Core-V SIMD instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -277,14 +277,14 @@ let Predicates = [HasExtXcvsimd], hasSideEffects = 0, mayLoad = 0, mayStore = 0 
 
   def CV_SHUFFLE_H :    CVSIMDALURR<0b11000, 0, 0, 0b000, "cv.shuffle.h">;
   def CV_SHUFFLE_B :    CVSIMDALURR<0b11000, 0, 0, 0b001, "cv.shuffle.b">;
-  def CV_SHUFFLE_SCI_H : CVSIMDALURI<0b11000, 0, 0b110, "cv.shuffle.sci.h">;
-  def CV_SHUFFLEI0_SCI_B : CVSIMDALURI<0b11000, 0, 0b111, "cv.shufflei0.sci.b">;
+  def CV_SHUFFLE_SCI_H : CVSIMDALURU<0b11000, 0, 0b110, "cv.shuffle.sci.h">;
+  def CV_SHUFFLEI0_SCI_B : CVSIMDALURU<0b11000, 0, 0b111, "cv.shufflei0.sci.b">;
 
-  def CV_SHUFFLEI1_SCI_B : CVSIMDALURI<0b11001, 0, 0b111, "cv.shufflei1.sci.b">;
+  def CV_SHUFFLEI1_SCI_B : CVSIMDALURU<0b11001, 0, 0b111, "cv.shufflei1.sci.b">;
 
-  def CV_SHUFFLEI2_SCI_B : CVSIMDALURI<0b11010, 0, 0b111, "cv.shufflei2.sci.b">;
+  def CV_SHUFFLEI2_SCI_B : CVSIMDALURU<0b11010, 0, 0b111, "cv.shufflei2.sci.b">;
 
-  def CV_SHUFFLEI3_SCI_B : CVSIMDALURI<0b11011, 0, 0b111, "cv.shufflei3.sci.b">;
+  def CV_SHUFFLEI3_SCI_B : CVSIMDALURU<0b11011, 0, 0b111, "cv.shufflei3.sci.b">;
 
   def CV_SHUFFLE2_H :    CVSIMDALURRWb<0b11100, 0, 0, 0b000, "cv.shuffle2.h">;
   def CV_SHUFFLE2_B :    CVSIMDALURRWb<0b11100, 0, 0, 0b001, "cv.shuffle2.b">;

--- a/llvm/test/MC/RISCV/corev/simd-all-extensions.s
+++ b/llvm/test/MC/RISCV/corev/simd-all-extensions.s
@@ -2348,8 +2348,8 @@ cv.shuffle.b s0, s1, s2
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b 94 24 c1 <unknown>
 
-cv.shuffle.sci.h t0, t1, -32
-# CHECK-INSTR: cv.shuffle.sci.h t0, t1, -32
+cv.shuffle.sci.h t0, t1, 32
+# CHECK-INSTR: cv.shuffle.sci.h t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x62,0x03,0xc1] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: fb 62 03 c1 <unknown>
@@ -2360,14 +2360,14 @@ cv.shuffle.sci.h a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e5 35 c2 <unknown>
 
-cv.shuffle.sci.h s0, s1, -1
-# CHECK-INSTR: cv.shuffle.sci.h s0, s1, -1
+cv.shuffle.sci.h s0, s1, 63
+# CHECK-INSTR: cv.shuffle.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0xc3] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e4 f4 c3 <unknown>
 
-cv.shufflei0.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei0.sci.b t0, t1, -32
+cv.shufflei0.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei0.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xc1] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: fb 72 03 c1 <unknown>
@@ -2378,14 +2378,14 @@ cv.shufflei0.sci.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f5 35 c2 <unknown>
 
-cv.shufflei0.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei0.sci.b s0, s1, -1
+cv.shufflei0.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei0.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xc3] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 c3 <unknown>
 
-cv.shufflei1.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei1.sci.b t0, t1, -32
+cv.shufflei1.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei1.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xc9] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: fb 72 03 c9 <unknown>
@@ -2396,14 +2396,14 @@ cv.shufflei1.sci.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f5 35 ca <unknown>
 
-cv.shufflei1.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei1.sci.b s0, s1, -1
+cv.shufflei1.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei1.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xcb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 cb <unknown>
 
-cv.shufflei2.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei2.sci.b t0, t1, -32
+cv.shufflei2.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei2.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xd1] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: fb 72 03 d1 <unknown>
@@ -2414,14 +2414,14 @@ cv.shufflei2.sci.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f5 35 d2 <unknown>
 
-cv.shufflei2.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei2.sci.b s0, s1, -1
+cv.shufflei2.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei2.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xd3] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 d3 <unknown>
 
-cv.shufflei3.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei3.sci.b t0, t1, -32
+cv.shufflei3.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei3.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xd9] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: fb 72 03 d9 <unknown>
@@ -2432,8 +2432,8 @@ cv.shufflei3.sci.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f5 35 da <unknown>
 
-cv.shufflei3.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei3.sci.b s0, s1, -1
+cv.shufflei3.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei3.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xdb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 db <unknown>

--- a/llvm/test/MC/RISCV/corev/simd/shuffle-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffle-invalid.s
@@ -56,13 +56,13 @@ cv.shuffle.sci.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle.sci.h t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffle.sci.h t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.shuffle.sci.h t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.shuffle.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffle.sci.h t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/shuffle.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffle.s
@@ -37,15 +37,15 @@ cv.shuffle.b s0, s1, s2
 // cv.shuffle.sci.h
 //===----------------------------------------------------------------------===//
 
-cv.shuffle.sci.h t0, t1, -32
-# CHECK-INSTR: cv.shuffle.sci.h t0, t1, -32
+cv.shuffle.sci.h t0, t1, 32
+# CHECK-INSTR: cv.shuffle.sci.h t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x62,0x03,0xc1]
 
 cv.shuffle.sci.h a0, a1, 7
 # CHECK-INSTR: cv.shuffle.sci.h a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xe5,0x35,0xc2]
 
-cv.shuffle.sci.h s0, s1, -1
-# CHECK-INSTR: cv.shuffle.sci.h s0, s1, -1
+cv.shuffle.sci.h s0, s1, 63
+# CHECK-INSTR: cv.shuffle.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0xc3]
 

--- a/llvm/test/MC/RISCV/corev/simd/shuffleIx-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffleIx-invalid.s
@@ -12,13 +12,13 @@ cv.shuffleI0.sci.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffleI0.sci.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI0.sci.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.shuffleI0.sci.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.shuffleI0.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI0.sci.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -34,13 +34,13 @@ cv.shuffleI1.sci.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffleI1.sci.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI1.sci.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.shuffleI1.sci.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.shuffleI1.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI1.sci.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -56,13 +56,13 @@ cv.shuffleI2.sci.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffleI2.sci.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI2.sci.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.shuffleI2.sci.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.shuffleI2.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI2.sci.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -78,13 +78,13 @@ cv.shuffleI3.sci.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffleI3.sci.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI3.sci.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.shuffleI3.sci.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.shuffleI3.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.shuffleI3.sci.b t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/shuffleIx.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffleIx.s
@@ -5,63 +5,63 @@
 // cv.shufflei0.sci.b
 //===----------------------------------------------------------------------===//
 
-cv.shufflei0.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei0.sci.b t0, t1, -32
+cv.shufflei0.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei0.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xc1]
 
 cv.shufflei0.sci.b a0, a1, 7
 # CHECK-INSTR: cv.shufflei0.sci.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xf5,0x35,0xc2]
 
-cv.shufflei0.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei0.sci.b s0, s1, -1
+cv.shufflei0.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei0.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xc3]
 
 //===----------------------------------------------------------------------===//
 // cv.shufflei1.sci.b
 //===----------------------------------------------------------------------===//
 
-cv.shufflei1.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei1.sci.b t0, t1, -32
+cv.shufflei1.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei1.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xc9]
 
 cv.shufflei1.sci.b a0, a1, 7
 # CHECK-INSTR: cv.shufflei1.sci.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xf5,0x35,0xca]
 
-cv.shufflei1.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei1.sci.b s0, s1, -1
+cv.shufflei1.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei1.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xcb]
 
 //===----------------------------------------------------------------------===//
 // cv.shufflei2.sci.b
 //===----------------------------------------------------------------------===//
 
-cv.shufflei2.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei2.sci.b t0, t1, -32
+cv.shufflei2.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei2.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xd1]
 
 cv.shufflei2.sci.b a0, a1, 7
 # CHECK-INSTR: cv.shufflei2.sci.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xf5,0x35,0xd2]
 
-cv.shufflei2.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei2.sci.b s0, s1, -1
+cv.shufflei2.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei2.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xd3]
 
 //===----------------------------------------------------------------------===//
 // cv.shufflei3.sci.b
 //===----------------------------------------------------------------------===//
 
-cv.shufflei3.sci.b t0, t1, -32
-# CHECK-INSTR: cv.shufflei3.sci.b t0, t1, -32
+cv.shufflei3.sci.b t0, t1, 32
+# CHECK-INSTR: cv.shufflei3.sci.b t0, t1, 32
 # CHECK-ENCODING: [0xfb,0x72,0x03,0xd9]
 
 cv.shufflei3.sci.b a0, a1, 7
 # CHECK-INSTR: cv.shufflei3.sci.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xf5,0x35,0xda]
 
-cv.shufflei3.sci.b s0, s1, -1
-# CHECK-INSTR: cv.shufflei3.sci.b s0, s1, -1
+cv.shufflei3.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei3.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0xdb]
 


### PR DESCRIPTION
#28 detected that signedness of a few instructions were wrong. This patch fixes them and updates relevant tests.