### PR TITLE
[RISCV] Support encoding bit manipulation instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCV.td
+++ b/llvm/lib/Target/RISCV/RISCV.td
@@ -448,6 +448,14 @@ def HasExtXcvsimd
                AssemblerPredicate<(any_of FeatureExtXcvsimd),
                "'Xcvsimd' (SIMD ALU)">;
 
+def FeatureExtXcvbitmanip
+    : SubtargetFeature<"xcvbitmanip", "HasExtXcvbitmanip", "true",
+                       "'Xcvbitmanip' (bit manipulation)">;
+def HasExtXcvbitmanip
+    : Predicate<"Subtarget->hasExtXcvbitmanip()">,
+               AssemblerPredicate<(any_of FeatureExtXcvbitmanip),
+               "'Xcvbitmanip' (bit manipulation)">;
+
 // CORE-V Load-Store Extension
 def FeatureExtXCoreVMem
     : SubtargetFeature<"xcorevmem", "HasExtXCoreVMem", "true",
@@ -462,7 +470,7 @@ def FeatureExtXCoreV
                        "'Xcorev' (CORE-V extensions)",
                        [FeatureExtXCoreVHwlp, FeatureExtXCoreVMac,
                         FeatureExtXCoreVAlu, FeatureExtXcvsimd, 
-                        FeatureExtXCoreVMem]>;
+                        FeatureExtXcvbitmanip, FeatureExtXCoreVMem]>;
 def HasExtXCoreV : Predicate<"Subtarget->hasExtXCoreV()">,
                               AssemblerPredicate<(all_of FeatureExtXCoreV),
                               "'Xcorev' (CORE-V extensions)">;

--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsCOREV.td
@@ -335,3 +335,20 @@ class CVInstSIMDRI<bits<5> funct5, bit F, bits<3> funct3, RISCVOpcode opcode, da
   let Opcode = opcode.Value;
   let DecoderNamespace = "CoreVSIMD";
 }
+
+class RVInstBitManip<bits<2> funct2, bits<3> funct3, dag outs, dag ins,
+                    string opcodestr, string argstr, list<dag> pattern>
+    : RVInst<outs, ins, opcodestr, argstr, pattern, InstFormatOther> {
+  bits<5> is3;
+  bits<5> is2;
+  bits<5> rs1;
+  bits<5> rd;
+
+  let Inst{31-30} = funct2;
+  let Inst{29-25} = is3;
+  let Inst{24-20} = is2;
+  let Inst{19-15} = rs1;
+  let Inst{14-12} = funct3;
+  let Inst{11-7} = rd;
+  let Opcode = OPC_CUSTOM2.Value;
+}

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -584,7 +584,48 @@ let Predicates = [HasExtXCoreVMem], hasSideEffects = 0, mayLoad = 0, mayStore = 
 
 } // Predicates = [HasExtXCoreVMem], hasSideEffects = 0, mayLoad = 0, mayStore = 1
 
+class CVBitManipRII<bits<2> funct2, bits<3> funct3, string opcodestr>
+  : RVInstBitManip<funct2, funct3, (outs GPR:$rd), (ins GPR:$rs1, uimm5:$is3, uimm5:$is2), 
+                   opcodestr, "$rd, $rs1, $is3, $is2", []>;
 
+class CVBitManipRR<bits<7> funct7, string opcodestr>
+  : RVInstAlu_rr<funct7, 0b011, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2), 
+                   opcodestr, "$rd, $rs1, $rs2", []>;
+
+class CVBitManipR<bits<7> funct7, string opcodestr>
+  : RVInstAlu_r<funct7, 0b011, (outs GPR:$rd), (ins GPR:$rs1), 
+                   opcodestr, "$rd, $rs1", []>;
+
+let Predicates = [HasExtXcvbitmanip, IsRV32], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
+  def CV_EXTRACT : CVBitManipRII<0b00, 0b000, "cv.extract">;
+  def CV_EXTRACTU : CVBitManipRII<0b01, 0b000, "cv.extractu">;
+
+  def CV_BCLR : CVBitManipRII<0b00, 0b001, "cv.bclr">;
+  def CV_BSET : CVBitManipRII<0b01, 0b001, "cv.bset">;
+  def CV_BITREV : RVInstBitManip<0b11, 0b001, (outs GPR:$rd), (ins GPR:$rs1, uimm2:$is3, uimm5:$is2), 
+                                 "cv.bitrev", "$rd, $rs1, $is3, $is2", []>;
+
+  def CV_EXTRACTR : CVBitManipRR<0b0011000, "cv.extractr">;
+  def CV_EXTRACTUR : CVBitManipRR<0b0011001, "cv.extractur">;
+
+  let Constraints = "$rd = $rd_wb" in {
+  def CV_INSERT : RVInstBitManip<0b10, 0b000, (outs GPR:$rd_wb), 
+                                 (ins GPR:$rs1, uimm5:$is3, uimm5:$is2, GPR:$rd), 
+                                 "cv.insert", "$rd, $rs1, $is3, $is2", []>;
+  def CV_INSERTR : RVInstAlu_rr<0b0011010, 0b011, (outs GPR:$rd_wb), 
+                                 (ins GPR:$rs1, GPR:$rs2, GPR:$rd), 
+                                 "cv.insertr", "$rd, $rs1, $rs2", []>;
+  }
+
+  def CV_BCLRR : CVBitManipRR<0b0011100, "cv.bclrr">;
+  def CV_BSETR : CVBitManipRR<0b0011101, "cv.bsetr">;
+
+  def CV_ROR : CVBitManipRR<0b0100000, "cv.ror">;
+  def CV_FF1 : CVBitManipR<0b0100001, "cv.ff1">;
+  def CV_FL1 : CVBitManipR<0b0100010, "cv.fl1">;
+  def CV_CLB : CVBitManipR<0b0100011, "cv.clb">;
+  def CV_CNT : CVBitManipR<0b0100100, "cv.cnt">;
+}
 
 //===----------------------------------------------------------------------===//
 // CORE-V specific helper fragments

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -100,6 +100,7 @@ private:
   bool HasExtXCoreVAlu = false;
   bool HasExtXCoreVMem = false;
   bool HasExtXcvsimd = false;
+  bool HasExtXcvbitmanip = false;
   bool HasRV64 = false;
   bool IsRV32E = false;
   bool EnableLinkerRelax = false;
@@ -207,6 +208,7 @@ public:
   bool hasExtXCoreVAlu() const { return HasExtXCoreVAlu; }
   bool hasExtXCoreVMem() const { return HasExtXCoreVMem; }
   bool hasExtXcvsimd() const { return HasExtXcvsimd; }
+  bool hasExtXcvbitmanip() const { return HasExtXcvbitmanip; }
   bool is64Bit() const { return HasRV64; }
   bool isRV32E() const { return IsRV32E; }
   bool enableLinkerRelax() const { return EnableLinkerRelax; }

--- a/llvm/test/MC/RISCV/corev/bitmanip/bclr-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bclr-invalid.s
@@ -1,0 +1,27 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.bclr t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+cv.bclr t0, t1, 0
+# CHECK-ERROR: too few operands for instruction
+
+cv.bclr t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bclr t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bclr t0, t1, 0, 32
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bclr t0, t1, 0, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bclr t0, t1, 32, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bclr t0, t1, -1, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bclr.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bclr.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.bclr t0, t1, 0, 1
+# CHECK-INSTR: cv.bclr t0, t1, 0, 1
+# CHECK-ENCODING: [0xdb,0x12,0x13,0x00]
+
+cv.bclr a0, a1, 17, 18
+# CHECK-INSTR: cv.bclr a0, a1, 17, 18
+# CHECK-ENCODING: [0x5b,0x95,0x25,0x23]
+
+cv.bclr s0, s1, 30, 31
+# CHECK-INSTR: cv.bclr s0, s1, 30, 31
+# CHECK-ENCODING: [0x5b,0x94,0xf4,0x3d]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bclrr-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bclrr-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.bclrr t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.bclrr t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.bclrr t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.bclrr t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bclrr.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bclrr.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.bclrr t0, t1, t2
+# CHECK-INSTR: cv.bclrr t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x38]
+
+cv.bclrr a0, a1, a2
+# CHECK-INSTR: cv.bclrr a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x38]
+
+cv.bclrr s0, s1, s2
+# CHECK-INSTR: cv.bclrr s0, s1, s2
+# CHECK-ENCODING: [0x2b,0xb4,0x24,0x39]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bitrev-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bitrev-invalid.s
@@ -1,0 +1,27 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.bitrev t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+cv.bitrev t0, t1, 0
+# CHECK-ERROR: too few operands for instruction
+
+cv.bitrev t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 3]
+
+cv.bitrev t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 3]
+
+cv.bitrev t0, t1, 0, 32
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bitrev t0, t1, 0, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bitrev t0, t1, 32, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 3]
+
+cv.bitrev t0, t1, -1, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 3]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bitrev.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bitrev.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.bitrev t0, t1, 0, 1
+# CHECK-INSTR: cv.bitrev t0, t1, 0, 1
+# CHECK-ENCODING: [0xdb,0x12,0x13,0xc0]
+
+cv.bitrev a0, a1, 1, 18
+# CHECK-INSTR: cv.bitrev a0, a1, 1, 18
+# CHECK-ENCODING: [0x5b,0x95,0x25,0xc3]
+
+cv.bitrev s0, s1, 2, 31
+# CHECK-INSTR: cv.bitrev s0, s1, 2, 31
+# CHECK-ENCODING: [0x5b,0x94,0xf4,0xc5]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bset-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bset-invalid.s
@@ -1,0 +1,27 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.bset t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+cv.bset t0, t1, 0
+# CHECK-ERROR: too few operands for instruction
+
+cv.bset t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bset t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bset t0, t1, 0, 32
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bset t0, t1, 0, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bset t0, t1, 32, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.bset t0, t1, -1, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bset.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bset.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.bset t0, t1, 0, 1
+# CHECK-INSTR: cv.bset t0, t1, 0, 1
+# CHECK-ENCODING: [0xdb,0x12,0x13,0x40]
+
+cv.bset a0, a1, 17, 18
+# CHECK-INSTR: cv.bset a0, a1, 17, 18
+# CHECK-ENCODING: [0x5b,0x95,0x25,0x63]
+
+cv.bset s0, s1, 30, 31
+# CHECK-INSTR: cv.bset s0, s1, 30, 31
+# CHECK-ENCODING: [0x5b,0x94,0xf4,0x7d]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bsetr-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bsetr-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.bsetr t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.bsetr t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.bsetr t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.bsetr t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/bsetr.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/bsetr.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.bsetr t0, t1, t2
+# CHECK-INSTR: cv.bsetr t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x3a]
+
+cv.bsetr a0, a1, a2
+# CHECK-INSTR: cv.bsetr a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x3a]
+
+cv.bsetr s0, s1, s2
+# CHECK-INSTR: cv.bsetr s0, s1, s2
+# CHECK-ENCODING: [0x2b,0xb4,0x24,0x3b]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/clb-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/clb-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.clb t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.clb t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.clb t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.clb t0, t1, t2
+# CHECK-ERROR: invalid operand for instruction 
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/clb.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/clb.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.clb t0, t1
+# CHECK-INSTR: cv.clb t0, t1
+# CHECK-ENCODING: [0xab,0x32,0x03,0x46]
+
+cv.clb a0, a1
+# CHECK-INSTR: cv.clb a0, a1
+# CHECK-ENCODING: [0x2b,0xb5,0x05,0x46]
+
+cv.clb s0, s1
+# CHECK-INSTR: cv.clb s0, s1
+# CHECK-ENCODING: [0x2b,0xb4,0x04,0x46]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/cnt-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/cnt-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.cnt t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.cnt t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cnt t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cnt t0, t1, t2
+# CHECK-ERROR: invalid operand for instruction 
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/cnt.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/cnt.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.cnt t0, t1
+# CHECK-INSTR: cv.cnt t0, t1
+# CHECK-ENCODING: [0xab,0x32,0x03,0x48]
+
+cv.cnt a0, a1
+# CHECK-INSTR: cv.cnt a0, a1
+# CHECK-ENCODING: [0x2b,0xb5,0x05,0x48]
+
+cv.cnt s0, s1
+# CHECK-INSTR: cv.cnt s0, s1
+# CHECK-ENCODING: [0x2b,0xb4,0x04,0x48]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extract-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extract-invalid.s
@@ -1,0 +1,27 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.extract t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+cv.extract t0, t1, 0
+# CHECK-ERROR: too few operands for instruction
+
+cv.extract t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extract t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extract t0, t1, 0, 32
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extract t0, t1, 0, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extract t0, t1, 32, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extract t0, t1, -1, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extract.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extract.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.extract t0, t1, 0, 1
+# CHECK-INSTR: cv.extract t0, t1, 0, 1
+# CHECK-ENCODING: [0xdb,0x02,0x13,0x00]
+
+cv.extract a0, a1, 17, 18
+# CHECK-INSTR: cv.extract a0, a1, 17, 18
+# CHECK-ENCODING: [0x5b,0x85,0x25,0x23]
+
+cv.extract s0, s1, 30, 31
+# CHECK-INSTR: cv.extract s0, s1, 30, 31
+# CHECK-ENCODING: [0x5b,0x84,0xf4,0x3d]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extractr-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extractr-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.extractr t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.extractr t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractr t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractr t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extractr.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extractr.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.extractr t0, t1, t2
+# CHECK-INSTR: cv.extractr t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x30]
+
+cv.extractr a0, a1, a2
+# CHECK-INSTR: cv.extractr a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x30]
+
+cv.extractr s0, s1, s2
+# CHECK-INSTR: cv.extractr s0, s1, s2
+# CHECK-ENCODING: [0x2b,0xb4,0x24,0x31]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extractu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extractu-invalid.s
@@ -1,0 +1,27 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.extractu t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+cv.extractu t0, t1, 0
+# CHECK-ERROR: too few operands for instruction
+
+cv.extractu t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extractu t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extractu t0, t1, 0, 32
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extractu t0, t1, 0, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extractu t0, t1, 32, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.extractu t0, t1, -1, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extractu.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extractu.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.extractu t0, t1, 0, 1
+# CHECK-INSTR: cv.extractu t0, t1, 0, 1
+# CHECK-ENCODING: [0xdb,0x02,0x13,0x40]
+
+cv.extractu a0, a1, 17, 18
+# CHECK-INSTR: cv.extractu a0, a1, 17, 18
+# CHECK-ENCODING: [0x5b,0x85,0x25,0x63]
+
+cv.extractu s0, s1, 30, 31
+# CHECK-INSTR: cv.extractu s0, s1, 30, 31
+# CHECK-ENCODING: [0x5b,0x84,0xf4,0x7d]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extractur-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extractur-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.extractur t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.extractur t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractur t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractur t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/extractur.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/extractur.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.extractur t0, t1, t2
+# CHECK-INSTR: cv.extractur t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x32]
+
+cv.extractur a0, a1, a2
+# CHECK-INSTR: cv.extractur a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x32]
+
+cv.extractur s0, s1, s2
+# CHECK-INSTR: cv.extractur s0, s1, s2
+# CHECK-ENCODING: [0x2b,0xb4,0x24,0x33]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/ff1-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/ff1-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.ff1 t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.ff1 t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.ff1 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.ff1 t0, t1, t2
+# CHECK-ERROR: invalid operand for instruction 
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/ff1.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/ff1.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.ff1 t0, t1
+# CHECK-INSTR: cv.ff1 t0, t1
+# CHECK-ENCODING: [0xab,0x32,0x03,0x42]
+
+cv.ff1 a0, a1
+# CHECK-INSTR: cv.ff1 a0, a1
+# CHECK-ENCODING: [0x2b,0xb5,0x05,0x42]
+
+cv.ff1 s0, s1
+# CHECK-INSTR: cv.ff1 s0, s1
+# CHECK-ENCODING: [0x2b,0xb4,0x04,0x42]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/fl1-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/fl1-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.fl1 t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.fl1 t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.fl1 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.fl1 t0, t1, t2
+# CHECK-ERROR: invalid operand for instruction 
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/fl1.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/fl1.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.fl1 t0, t1
+# CHECK-INSTR: cv.fl1 t0, t1
+# CHECK-ENCODING: [0xab,0x32,0x03,0x44]
+
+cv.fl1 a0, a1
+# CHECK-INSTR: cv.fl1 a0, a1
+# CHECK-ENCODING: [0x2b,0xb5,0x05,0x44]
+
+cv.fl1 s0, s1
+# CHECK-INSTR: cv.fl1 s0, s1
+# CHECK-ENCODING: [0x2b,0xb4,0x04,0x44]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/insert-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/insert-invalid.s
@@ -1,0 +1,27 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.insert t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+cv.insert t0, t1, 0
+# CHECK-ERROR: too few operands for instruction
+
+cv.insert t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.insert t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.insert t0, t1, 0, 32
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.insert t0, t1, 0, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.insert t0, t1, 32, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+
+cv.insert t0, t1, -1, 0
+# CHECK-ERROR: immediate must be an integer in the range [0, 31]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/insert.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/insert.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.insert t0, t1, 0, 1
+# CHECK-INSTR: cv.insert t0, t1, 0, 1
+# CHECK-ENCODING: [0xdb,0x02,0x13,0x80]
+
+cv.insert a0, a1, 17, 18
+# CHECK-INSTR: cv.insert a0, a1, 17, 18
+# CHECK-ENCODING: [0x5b,0x85,0x25,0xa3]
+
+cv.insert s0, s1, 30, 31
+# CHECK-INSTR: cv.insert s0, s1, 30, 31
+# CHECK-ENCODING: [0x5b,0x84,0xf4,0xbd]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/insertr-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/insertr-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.insertr t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.insertr t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.insertr t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.insertr t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/insertr.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/insertr.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.insertr t0, t1, t2
+# CHECK-INSTR: cv.insertr t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x34]
+
+cv.insertr a0, a1, a2
+# CHECK-INSTR: cv.insertr a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x34]
+
+cv.insertr s0, s1, s2
+# CHECK-INSTR: cv.insertr s0, s1, s2
+# CHECK-ENCODING: [0x2b,0xb4,0x24,0x35]
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/ror-invalid.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/ror-invalid.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvbitmanip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+cv.ror t0
+# CHECK-ERROR: too few operands for instruction
+
+cv.ror t0, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.ror t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.ror t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/bitmanip/ror.s
+++ b/llvm/test/MC/RISCV/corev/bitmanip/ror.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvbitmanip -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+cv.ror t0, t1, t2
+# CHECK-INSTR: cv.ror t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x40]
+
+cv.ror a0, a1, a2
+# CHECK-INSTR: cv.ror a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x40]
+
+cv.ror s0, s1, s2
+# CHECK-INSTR: cv.ror s0, s1, s2
+# CHECK-ENCODING: [0x2b,0xb4,0x24,0x41]
+


### PR DESCRIPTION
Spec: https://github.com/openhwgroup/cv32e40p/blob/e1d33c596b741f3bd042030effc93b32cba36276/docs/source/instruction_set_extensions.rst#bit-manipulation-operations