### PR TITLE
 [CI] Enable CI tests for clang 

### DIFF
--- a/.github/workflows/corev-llvm-tests.yml
+++ b/.github/workflows/corev-llvm-tests.yml
@@ -8,6 +8,7 @@ on:
       - 'development'
     paths:
       - 'llvm/**'
+      - 'clang/**'
       - '.github/workflows/corev-llvm-tests.yml'
       - '.github/workflows/llvm-project-tests.yml'
   pull_request:
@@ -16,6 +17,7 @@ on:
       - 'development'
     paths:
       - 'llvm/**'
+      - 'clang/**'
       - '.github/workflows/corev-llvm-tests.yml'
       - '.github/workflows/llvm-project-tests.yml'
 


### PR DESCRIPTION
The workflow for running tests is only triggered on the folder `llvm`, while #32 only changes the folder `clang`, which is why the *llvm-lit* tests are not enabled on it. This PR enables tests for PRs that only modify the folder `clang` to fix it.