### PR TITLE
 [RISCV] Update Core-V SIMD instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -250,9 +250,9 @@ let Predicates = [HasExtXcvsimd], hasSideEffects = 0, mayLoad = 0, mayStore = 0 
   defm SRL :  CVSIMDBinaryUnsigned<0b01000, 0, 0, "srl">;
   defm SRA :  CVSIMDBinaryUnsigned<0b01001, 0, 0, "sra">;
   defm SLL :  CVSIMDBinaryUnsigned<0b01010, 0, 0, "sll">;
-  defm OR :     CVSIMDBinarySigned<0b01011, 0, 0, "or">;
-  defm XOR :    CVSIMDBinarySigned<0b01100, 0, 0, "xor">;
-  defm AND :    CVSIMDBinarySigned<0b01101, 0, 0, "and">;
+  defm OR :     CVSIMDBinaryUnsigned<0b01011, 0, 0, "or">;
+  defm XOR :    CVSIMDBinaryUnsigned<0b01100, 0, 0, "xor">;
+  defm AND :    CVSIMDBinaryUnsigned<0b01101, 0, 0, "and">;
 
   def CV_ABS_H :    CVSIMDALUR<0b01110, 0, 0, 0b000, "cv.abs.h">;
   def CV_ABS_B :    CVSIMDALUR<0b01110, 0, 0, 0b001, "cv.abs.b">;
@@ -268,12 +268,12 @@ let Predicates = [HasExtXcvsimd], hasSideEffects = 0, mayLoad = 0, mayStore = 0 
 
   // 0b10110xx: UNDEF
 
-  def CV_EXTRACT_H :    CVSIMDALURI<0b10111, 0, 0b000, "cv.extract.h">;
-  def CV_EXTRACT_B :    CVSIMDALURI<0b10111, 0, 0b001, "cv.extract.b">;
-  def CV_EXTRACTU_H :   CVSIMDALURI<0b10111, 0, 0b010, "cv.extractu.h">;
-  def CV_EXTRACTU_B :   CVSIMDALURI<0b10111, 0, 0b011, "cv.extractu.b">;
-  def CV_INSERT_H :     CVSIMDALURIWb<0b10111, 0, 0b100, "cv.insert.h">;
-  def CV_INSERT_B :     CVSIMDALURIWb<0b10111, 0, 0b101, "cv.insert.b">;
+  def CV_EXTRACT_H :    CVSIMDALURU<0b10111, 0, 0b000, "cv.extract.h">;
+  def CV_EXTRACT_B :    CVSIMDALURU<0b10111, 0, 0b001, "cv.extract.b">;
+  def CV_EXTRACTU_H :   CVSIMDALURU<0b10111, 0, 0b010, "cv.extractu.h">;
+  def CV_EXTRACTU_B :   CVSIMDALURU<0b10111, 0, 0b011, "cv.extractu.b">;
+  def CV_INSERT_H :     CVSIMDALURUWb<0b10111, 0, 0b100, "cv.insert.h">;
+  def CV_INSERT_B :     CVSIMDALURUWb<0b10111, 0, 0b101, "cv.insert.b">;
 
   def CV_SHUFFLE_H :    CVSIMDALURR<0b11000, 0, 0, 0b000, "cv.shuffle.h">;
   def CV_SHUFFLE_B :    CVSIMDALURR<0b11000, 0, 0, 0b001, "cv.shuffle.b">;

--- a/llvm/test/MC/RISCV/corev/simd-all-extensions.s
+++ b/llvm/test/MC/RISCV/corev/simd-all-extensions.s
@@ -1268,11 +1268,17 @@ cv.or.sc.b s0, s1, s2
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b d4 24 59 <unknown>
 
-cv.or.sci.h t0, t1, -32
-# CHECK-INSTR: cv.or.sci.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x62,0x03,0x59] 
+cv.or.sci.h t0, t1, 0
+# CHECK-INSTR: cv.or.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x58] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 62 03 59 <unknown>
+# CHECK-UNKNOWN: fb 62 03 58 <unknown>
+
+cv.or.sci.h t3, t4, 32
+# CHECK-INSTR: cv.or.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x59] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b ee 0e 59 <unknown>
 
 cv.or.sci.h a0, a1, 7
 # CHECK-INSTR: cv.or.sci.h a0, a1, 7
@@ -1280,17 +1286,23 @@ cv.or.sci.h a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e5 35 5a <unknown>
 
-cv.or.sci.h s0, s1, -1
-# CHECK-INSTR: cv.or.sci.h s0, s1, -1
+cv.or.sci.h s0, s1, 63
+# CHECK-INSTR: cv.or.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0x5b] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e4 f4 5b <unknown>
 
-cv.or.sci.b t0, t1, -32
-# CHECK-INSTR: cv.or.sci.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x72,0x03,0x59] 
+cv.or.sci.b t0, t1, 0
+# CHECK-INSTR: cv.or.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x58] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 72 03 59 <unknown>
+# CHECK-UNKNOWN: fb 72 03 58 <unknown>
+
+cv.or.sci.b t3, t4, 32
+# CHECK-INSTR: cv.or.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x59] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b fe 0e 59 <unknown>
 
 cv.or.sci.b a0, a1, 7
 # CHECK-INSTR: cv.or.sci.b a0, a1, 7
@@ -1298,8 +1310,8 @@ cv.or.sci.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f5 35 5a <unknown>
 
-cv.or.sci.b s0, s1, -1
-# CHECK-INSTR: cv.or.sci.b s0, s1, -1
+cv.or.sci.b s0, s1, 63
+# CHECK-INSTR: cv.or.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0x5b] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 5b <unknown>
@@ -1376,11 +1388,17 @@ cv.xor.sc.b s0, s1, s2
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b d4 24 61 <unknown>
 
-cv.xor.sci.h t0, t1, -32
-# CHECK-INSTR: cv.xor.sci.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x62,0x03,0x61] 
+cv.xor.sci.h t0, t1, 0
+# CHECK-INSTR: cv.xor.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x60] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 62 03 61 <unknown>
+# CHECK-UNKNOWN: fb 62 03 60 <unknown>
+
+cv.xor.sci.h t3, t4, 32
+# CHECK-INSTR: cv.xor.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x61] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b ee 0e 61 <unknown>
 
 cv.xor.sci.h a0, a1, 7
 # CHECK-INSTR: cv.xor.sci.h a0, a1, 7
@@ -1388,17 +1406,23 @@ cv.xor.sci.h a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e5 35 62 <unknown>
 
-cv.xor.sci.h s0, s1, -1
-# CHECK-INSTR: cv.xor.sci.h s0, s1, -1
+cv.xor.sci.h s0, s1, 63
+# CHECK-INSTR: cv.xor.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0x63] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e4 f4 63 <unknown>
 
-cv.xor.sci.b t0, t1, -32
-# CHECK-INSTR: cv.xor.sci.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x72,0x03,0x61] 
+cv.xor.sci.b t0, t1, 0
+# CHECK-INSTR: cv.xor.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x60] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 72 03 61 <unknown>
+# CHECK-UNKNOWN: fb 72 03 60 <unknown>
+
+cv.xor.sci.b t3, t4, 32
+# CHECK-INSTR: cv.xor.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x61] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b fe 0e 61 <unknown>
 
 cv.xor.sci.b a0, a1, 7
 # CHECK-INSTR: cv.xor.sci.b a0, a1, 7
@@ -1406,8 +1430,8 @@ cv.xor.sci.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f5 35 62 <unknown>
 
-cv.xor.sci.b s0, s1, -1
-# CHECK-INSTR: cv.xor.sci.b s0, s1, -1
+cv.xor.sci.b s0, s1, 63
+# CHECK-INSTR: cv.xor.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0x63] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 63 <unknown>
@@ -1484,11 +1508,17 @@ cv.and.sc.b s0, s1, s2
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b d4 24 69 <unknown>
 
-cv.and.sci.h t0, t1, -32
-# CHECK-INSTR: cv.and.sci.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x62,0x03,0x69] 
+cv.and.sci.h t0, t1, 0
+# CHECK-INSTR: cv.and.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x68] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 62 03 69 <unknown>
+# CHECK-UNKNOWN: fb 62 03 68 <unknown>
+
+cv.and.sci.h t3, t4, 32
+# CHECK-INSTR: cv.and.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x69] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b ee 0e 69 <unknown>
 
 cv.and.sci.h a0, a1, 7
 # CHECK-INSTR: cv.and.sci.h a0, a1, 7
@@ -1496,17 +1526,23 @@ cv.and.sci.h a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e5 35 6a <unknown>
 
-cv.and.sci.h s0, s1, -1
-# CHECK-INSTR: cv.and.sci.h s0, s1, -1
+cv.and.sci.h s0, s1, 63
+# CHECK-INSTR: cv.and.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0x6b] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b e4 f4 6b <unknown>
 
-cv.and.sci.b t0, t1, -32
-# CHECK-INSTR: cv.and.sci.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x72,0x03,0x69] 
+cv.and.sci.b t0, t1, 0
+# CHECK-INSTR: cv.and.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x68] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 72 03 69 <unknown>
+# CHECK-UNKNOWN: fb 72 03 68 <unknown>
+
+cv.and.sci.b t3, t4, 32
+# CHECK-INSTR: cv.and.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x69] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b fe 0e 69 <unknown>
 
 cv.and.sci.b a0, a1, 7
 # CHECK-INSTR: cv.and.sci.b a0, a1, 7
@@ -1514,8 +1550,8 @@ cv.and.sci.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f5 35 6a <unknown>
 
-cv.and.sci.b s0, s1, -1
-# CHECK-INSTR: cv.and.sci.b s0, s1, -1
+cv.and.sci.b s0, s1, 63
+# CHECK-INSTR: cv.and.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0x6b] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 6b <unknown>
@@ -2204,11 +2240,17 @@ cv.sdotsp.sci.b s0, s1, -1
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b f4 f4 ab <unknown>
 
-cv.extract.h t0, t1, -32
-# CHECK-INSTR: cv.extract.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x02,0x03,0xb9] 
+cv.extract.h t0, t1, 0
+# CHECK-INSTR: cv.extract.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x02,0x03,0xb8] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 02 03 b9 <unknown>
+# CHECK-UNKNOWN: fb 02 03 b8 <unknown>
+
+cv.extract.h t3, t4, 32
+# CHECK-INSTR: cv.extract.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0x8e,0x0e,0xb9] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b 8e 0e b9 <unknown>
 
 cv.extract.h a0, a1, 7
 # CHECK-INSTR: cv.extract.h a0, a1, 7
@@ -2216,17 +2258,23 @@ cv.extract.h a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b 85 35 ba <unknown>
 
-cv.extract.h s0, s1, -1
-# CHECK-INSTR: cv.extract.h s0, s1, -1
+cv.extract.h s0, s1, 63
+# CHECK-INSTR: cv.extract.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0x84,0xf4,0xbb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b 84 f4 bb <unknown>
 
-cv.extract.b t0, t1, -32
-# CHECK-INSTR: cv.extract.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x12,0x03,0xb9] 
+cv.extract.b t0, t1, 0
+# CHECK-INSTR: cv.extract.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x12,0x03,0xb8] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 12 03 b9 <unknown>
+# CHECK-UNKNOWN: fb 12 03 b8 <unknown>
+
+cv.extract.b t3, t4, 32
+# CHECK-INSTR: cv.extract.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0x9e,0x0e,0xb9] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b 9e 0e b9 <unknown>
 
 cv.extract.b a0, a1, 7
 # CHECK-INSTR: cv.extract.b a0, a1, 7
@@ -2234,17 +2282,23 @@ cv.extract.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b 95 35 ba <unknown>
 
-cv.extract.b s0, s1, -1
-# CHECK-INSTR: cv.extract.b s0, s1, -1
+cv.extract.b s0, s1, 63
+# CHECK-INSTR: cv.extract.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0x94,0xf4,0xbb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b 94 f4 bb <unknown>
 
-cv.extractu.h t0, t1, -32
-# CHECK-INSTR: cv.extractu.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x22,0x03,0xb9] 
+cv.extractu.h t0, t1, 0
+# CHECK-INSTR: cv.extractu.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x22,0x03,0xb8] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 22 03 b9 <unknown>
+# CHECK-UNKNOWN: fb 22 03 b8 <unknown>
+
+cv.extractu.h t3, t4, 32
+# CHECK-INSTR: cv.extractu.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xae,0x0e,0xb9] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b ae 0e b9 <unknown>
 
 cv.extractu.h a0, a1, 7
 # CHECK-INSTR: cv.extractu.h a0, a1, 7
@@ -2252,17 +2306,23 @@ cv.extractu.h a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b a5 35 ba <unknown>
 
-cv.extractu.h s0, s1, -1
-# CHECK-INSTR: cv.extractu.h s0, s1, -1
+cv.extractu.h s0, s1, 63
+# CHECK-INSTR: cv.extractu.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xa4,0xf4,0xbb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b a4 f4 bb <unknown>
 
-cv.extractu.b t0, t1, -32
-# CHECK-INSTR: cv.extractu.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x32,0x03,0xb9] 
+cv.extractu.b t0, t1, 0
+# CHECK-INSTR: cv.extractu.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x32,0x03,0xb8] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 32 03 b9 <unknown>
+# CHECK-UNKNOWN: fb 32 03 b8 <unknown>
+
+cv.extractu.b t3, t4, 32
+# CHECK-INSTR: cv.extractu.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xbe,0x0e,0xb9] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b be 0e b9 <unknown>
 
 cv.extractu.b a0, a1, 7
 # CHECK-INSTR: cv.extractu.b a0, a1, 7
@@ -2270,17 +2330,23 @@ cv.extractu.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b b5 35 ba <unknown>
 
-cv.extractu.b s0, s1, -1
-# CHECK-INSTR: cv.extractu.b s0, s1, -1
+cv.extractu.b s0, s1, 63
+# CHECK-INSTR: cv.extractu.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xb4,0xf4,0xbb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b b4 f4 bb <unknown>
 
-cv.insert.h t0, t1, -32
-# CHECK-INSTR: cv.insert.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x42,0x03,0xb9] 
+cv.insert.h t0, t1, 0
+# CHECK-INSTR: cv.insert.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x42,0x03,0xb8] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 42 03 b9 <unknown>
+# CHECK-UNKNOWN: fb 42 03 b8 <unknown>
+
+cv.insert.h t3, t4, 32
+# CHECK-INSTR: cv.insert.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xce,0x0e,0xb9] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b ce 0e b9 <unknown>
 
 cv.insert.h a0, a1, 7
 # CHECK-INSTR: cv.insert.h a0, a1, 7
@@ -2288,17 +2354,23 @@ cv.insert.h a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b c5 35 ba <unknown>
 
-cv.insert.h s0, s1, -1
-# CHECK-INSTR: cv.insert.h s0, s1, -1
+cv.insert.h s0, s1, 63
+# CHECK-INSTR: cv.insert.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xc4,0xf4,0xbb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b c4 f4 bb <unknown>
 
-cv.insert.b t0, t1, -32
-# CHECK-INSTR: cv.insert.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x52,0x03,0xb9] 
+cv.insert.b t0, t1, 0
+# CHECK-INSTR: cv.insert.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x52,0x03,0xb8] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
-# CHECK-UNKNOWN: fb 52 03 b9 <unknown>
+# CHECK-UNKNOWN: fb 52 03 b8 <unknown>
+
+cv.insert.b t3, t4, 32
+# CHECK-INSTR: cv.insert.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xde,0x0e,0xb9] 
+# CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
+# CHECK-UNKNOWN: 7b de 0e b9 <unknown>
 
 cv.insert.b a0, a1, 7
 # CHECK-INSTR: cv.insert.b a0, a1, 7
@@ -2306,8 +2378,8 @@ cv.insert.b a0, a1, 7
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b d5 35 ba <unknown>
 
-cv.insert.b s0, s1, -1
-# CHECK-INSTR: cv.insert.b s0, s1, -1
+cv.insert.b s0, s1, 63
+# CHECK-INSTR: cv.insert.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xd4,0xf4,0xbb] 
 # CHECK-ERROR: error: instruction requires the following: 'Xcvsimd' (SIMD ALU)
 # CHECK-UNKNOWN: 7b d4 f4 bb <unknown>

--- a/llvm/test/MC/RISCV/corev/simd/and-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/and-invalid.s
@@ -100,13 +100,16 @@ cv.and.sci.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.sci.h t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.and.sci.h t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.and.sci.h t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.and.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.and.sci.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -122,13 +125,16 @@ cv.and.sci.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.sci.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.and.sci.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.and.sci.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.and.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.and.sci.b t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/and.s
+++ b/llvm/test/MC/RISCV/corev/simd/and.s
@@ -9,6 +9,10 @@ cv.and.h t0, t1, t2
 # CHECK-INSTR: cv.and.h t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x02,0x73,0x68]
 
+cv.and.h t3, t4, t5
+# CHECK-INSTR: cv.and.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x69]
+
 cv.and.h a0, a1, a2
 # CHECK-INSTR: cv.and.h a0, a1, a2
 # CHECK-ENCODING: [0x7b,0x85,0xc5,0x68]
@@ -24,6 +28,10 @@ cv.and.h s0, s1, s2
 cv.and.b t0, t1, t2
 # CHECK-INSTR: cv.and.b t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x12,0x73,0x68]
+
+cv.and.b t3, t4, t5
+# CHECK-INSTR: cv.and.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x69]
 
 cv.and.b a0, a1, a2
 # CHECK-INSTR: cv.and.b a0, a1, a2
@@ -41,6 +49,10 @@ cv.and.sc.h t0, t1, t2
 # CHECK-INSTR: cv.and.sc.h t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x42,0x73,0x68]
 
+cv.and.sc.h t3, t4, t5
+# CHECK-INSTR: cv.and.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x69]
+
 cv.and.sc.h a0, a1, a2
 # CHECK-INSTR: cv.and.sc.h a0, a1, a2
 # CHECK-ENCODING: [0x7b,0xc5,0xc5,0x68]
@@ -57,6 +69,10 @@ cv.and.sc.b t0, t1, t2
 # CHECK-INSTR: cv.and.sc.b t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x52,0x73,0x68]
 
+cv.and.sc.b t3, t4, t5
+# CHECK-INSTR: cv.and.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x69]
+
 cv.and.sc.b a0, a1, a2
 # CHECK-INSTR: cv.and.sc.b a0, a1, a2
 # CHECK-ENCODING: [0x7b,0xd5,0xc5,0x68]
@@ -69,31 +85,39 @@ cv.and.sc.b s0, s1, s2
 // cv.and.sci.h
 //===----------------------------------------------------------------------===//
 
-cv.and.sci.h t0, t1, -32
-# CHECK-INSTR: cv.and.sci.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x62,0x03,0x69]
+cv.and.sci.h t0, t1, 0
+# CHECK-INSTR: cv.and.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x68]
+
+cv.and.sci.h t3, t4, 32
+# CHECK-INSTR: cv.and.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x69]
 
 cv.and.sci.h a0, a1, 7
 # CHECK-INSTR: cv.and.sci.h a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xe5,0x35,0x6a]
 
-cv.and.sci.h s0, s1, -1
-# CHECK-INSTR: cv.and.sci.h s0, s1, -1
+cv.and.sci.h s0, s1, 63
+# CHECK-INSTR: cv.and.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0x6b]
 
 //===----------------------------------------------------------------------===//
 // cv.and.sci.b
 //===----------------------------------------------------------------------===//
 
-cv.and.sci.b t0, t1, -32
-# CHECK-INSTR: cv.and.sci.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x72,0x03,0x69]
+cv.and.sci.b t0, t1, 0
+# CHECK-INSTR: cv.and.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x68]
+
+cv.and.sci.b t3, t4, 32
+# CHECK-INSTR: cv.and.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x69]
 
 cv.and.sci.b a0, a1, 7
 # CHECK-INSTR: cv.and.sci.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xf5,0x35,0x6a]
 
-cv.and.sci.b s0, s1, -1
-# CHECK-INSTR: cv.and.sci.b s0, s1, -1
+cv.and.sci.b s0, s1, 63
+# CHECK-INSTR: cv.and.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0x6b]
 

--- a/llvm/test/MC/RISCV/corev/simd/extract-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/extract-invalid.s
@@ -12,13 +12,16 @@ cv.extract.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.extract.h t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extract.h t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.extract.h t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.extract.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extract.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -34,13 +37,16 @@ cv.extract.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.extract.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extract.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.extract.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.extract.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extract.b t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/extract.s
+++ b/llvm/test/MC/RISCV/corev/simd/extract.s
@@ -5,31 +5,39 @@
 // cv.extract.h
 //===----------------------------------------------------------------------===//
 
-cv.extract.h t0, t1, -32
-# CHECK-INSTR: cv.extract.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x02,0x03,0xb9]
+cv.extract.h t0, t1, 0
+# CHECK-INSTR: cv.extract.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x02,0x03,0xb8]
+
+cv.extract.h t3, t4, 32
+# CHECK-INSTR: cv.extract.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0x8e,0x0e,0xb9]
 
 cv.extract.h a0, a1, 7
 # CHECK-INSTR: cv.extract.h a0, a1, 7
 # CHECK-ENCODING: [0x7b,0x85,0x35,0xba]
 
-cv.extract.h s0, s1, -1
-# CHECK-INSTR: cv.extract.h s0, s1, -1
+cv.extract.h s0, s1, 63
+# CHECK-INSTR: cv.extract.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0x84,0xf4,0xbb]
 
 //===----------------------------------------------------------------------===//
 // cv.extract.b
 //===----------------------------------------------------------------------===//
 
-cv.extract.b t0, t1, -32
-# CHECK-INSTR: cv.extract.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x12,0x03,0xb9]
+cv.extract.b t0, t1, 0
+# CHECK-INSTR: cv.extract.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x12,0x03,0xb8]
+
+cv.extract.b t3, t4, 32
+# CHECK-INSTR: cv.extract.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0x9e,0x0e,0xb9]
 
 cv.extract.b a0, a1, 7
 # CHECK-INSTR: cv.extract.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0x95,0x35,0xba]
 
-cv.extract.b s0, s1, -1
-# CHECK-INSTR: cv.extract.b s0, s1, -1
+cv.extract.b s0, s1, 63
+# CHECK-INSTR: cv.extract.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0x94,0xf4,0xbb]
 

--- a/llvm/test/MC/RISCV/corev/simd/extractu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/extractu-invalid.s
@@ -12,13 +12,16 @@ cv.extractu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.extractu.h t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extractu.h t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.extractu.h t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.extractu.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extractu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -34,13 +37,16 @@ cv.extractu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.extractu.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extractu.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.extractu.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.extractu.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.extractu.b t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/extractu.s
+++ b/llvm/test/MC/RISCV/corev/simd/extractu.s
@@ -5,31 +5,39 @@
 // cv.extractu.h
 //===----------------------------------------------------------------------===//
 
-cv.extractu.h t0, t1, -32
-# CHECK-INSTR: cv.extractu.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x22,0x03,0xb9]
+cv.extractu.h t0, t1, 0
+# CHECK-INSTR: cv.extractu.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x22,0x03,0xb8]
+
+cv.extractu.h t3, t4, 32
+# CHECK-INSTR: cv.extractu.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xae,0x0e,0xb9]
 
 cv.extractu.h a0, a1, 7
 # CHECK-INSTR: cv.extractu.h a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xa5,0x35,0xba]
 
-cv.extractu.h s0, s1, -1
-# CHECK-INSTR: cv.extractu.h s0, s1, -1
+cv.extractu.h s0, s1, 63
+# CHECK-INSTR: cv.extractu.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xa4,0xf4,0xbb]
 
 //===----------------------------------------------------------------------===//
 // cv.extractu.b
 //===----------------------------------------------------------------------===//
 
-cv.extractu.b t0, t1, -32
-# CHECK-INSTR: cv.extractu.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x32,0x03,0xb9]
+cv.extractu.b t0, t1, 0
+# CHECK-INSTR: cv.extractu.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x32,0x03,0xb8]
+
+cv.extractu.b t3, t4, 32
+# CHECK-INSTR: cv.extractu.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xbe,0x0e,0xb9]
 
 cv.extractu.b a0, a1, 7
 # CHECK-INSTR: cv.extractu.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xb5,0x35,0xba]
 
-cv.extractu.b s0, s1, -1
-# CHECK-INSTR: cv.extractu.b s0, s1, -1
+cv.extractu.b s0, s1, 63
+# CHECK-INSTR: cv.extractu.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xb4,0xf4,0xbb]
 

--- a/llvm/test/MC/RISCV/corev/simd/insert-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/insert-invalid.s
@@ -12,13 +12,16 @@ cv.insert.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.insert.h t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.insert.h t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.insert.h t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.insert.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.insert.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -34,13 +37,16 @@ cv.insert.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.insert.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.insert.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.insert.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.insert.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.insert.b t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/insert.s
+++ b/llvm/test/MC/RISCV/corev/simd/insert.s
@@ -5,31 +5,39 @@
 // cv.insert.h
 //===----------------------------------------------------------------------===//
 
-cv.insert.h t0, t1, -32
-# CHECK-INSTR: cv.insert.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x42,0x03,0xb9]
+cv.insert.h t0, t1, 0
+# CHECK-INSTR: cv.insert.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x42,0x03,0xb8]
+
+cv.insert.h t3, t4, 32
+# CHECK-INSTR: cv.insert.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xce,0x0e,0xb9]
 
 cv.insert.h a0, a1, 7
 # CHECK-INSTR: cv.insert.h a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xc5,0x35,0xba]
 
-cv.insert.h s0, s1, -1
-# CHECK-INSTR: cv.insert.h s0, s1, -1
+cv.insert.h s0, s1, 63
+# CHECK-INSTR: cv.insert.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xc4,0xf4,0xbb]
 
 //===----------------------------------------------------------------------===//
 // cv.insert.b
 //===----------------------------------------------------------------------===//
 
-cv.insert.b t0, t1, -32
-# CHECK-INSTR: cv.insert.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x52,0x03,0xb9]
+cv.insert.b t0, t1, 0
+# CHECK-INSTR: cv.insert.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x52,0x03,0xb8]
+
+cv.insert.b t3, t4, 32
+# CHECK-INSTR: cv.insert.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xde,0x0e,0xb9]
 
 cv.insert.b a0, a1, 7
 # CHECK-INSTR: cv.insert.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xd5,0x35,0xba]
 
-cv.insert.b s0, s1, -1
-# CHECK-INSTR: cv.insert.b s0, s1, -1
+cv.insert.b s0, s1, 63
+# CHECK-INSTR: cv.insert.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xd4,0xf4,0xbb]
 

--- a/llvm/test/MC/RISCV/corev/simd/or-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/or-invalid.s
@@ -100,13 +100,16 @@ cv.or.sci.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.sci.h t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.or.sci.h t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.or.sci.h t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.or.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.or.sci.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -122,13 +125,16 @@ cv.or.sci.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.sci.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.or.sci.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.or.sci.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.or.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.or.sci.b t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/or.s
+++ b/llvm/test/MC/RISCV/corev/simd/or.s
@@ -9,6 +9,10 @@ cv.or.h t0, t1, t2
 # CHECK-INSTR: cv.or.h t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x02,0x73,0x58]
 
+cv.or.h t3, t4, t5
+# CHECK-INSTR: cv.or.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x59]
+
 cv.or.h a0, a1, a2
 # CHECK-INSTR: cv.or.h a0, a1, a2
 # CHECK-ENCODING: [0x7b,0x85,0xc5,0x58]
@@ -24,6 +28,10 @@ cv.or.h s0, s1, s2
 cv.or.b t0, t1, t2
 # CHECK-INSTR: cv.or.b t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x12,0x73,0x58]
+
+cv.or.b t3, t4, t5
+# CHECK-INSTR: cv.or.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x59]
 
 cv.or.b a0, a1, a2
 # CHECK-INSTR: cv.or.b a0, a1, a2
@@ -41,6 +49,10 @@ cv.or.sc.h t0, t1, t2
 # CHECK-INSTR: cv.or.sc.h t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x42,0x73,0x58]
 
+cv.or.sc.h t3, t4, t5
+# CHECK-INSTR: cv.or.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x59]
+
 cv.or.sc.h a0, a1, a2
 # CHECK-INSTR: cv.or.sc.h a0, a1, a2
 # CHECK-ENCODING: [0x7b,0xc5,0xc5,0x58]
@@ -57,6 +69,10 @@ cv.or.sc.b t0, t1, t2
 # CHECK-INSTR: cv.or.sc.b t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x52,0x73,0x58]
 
+cv.or.sc.b t3, t4, t5
+# CHECK-INSTR: cv.or.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x59]
+
 cv.or.sc.b a0, a1, a2
 # CHECK-INSTR: cv.or.sc.b a0, a1, a2
 # CHECK-ENCODING: [0x7b,0xd5,0xc5,0x58]
@@ -69,31 +85,39 @@ cv.or.sc.b s0, s1, s2
 // cv.or.sci.h
 //===----------------------------------------------------------------------===//
 
-cv.or.sci.h t0, t1, -32
-# CHECK-INSTR: cv.or.sci.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x62,0x03,0x59]
+cv.or.sci.h t0, t1, 0
+# CHECK-INSTR: cv.or.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x58]
+
+cv.or.sci.h t3, t4, 32
+# CHECK-INSTR: cv.or.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x59]
 
 cv.or.sci.h a0, a1, 7
 # CHECK-INSTR: cv.or.sci.h a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xe5,0x35,0x5a]
 
-cv.or.sci.h s0, s1, -1
-# CHECK-INSTR: cv.or.sci.h s0, s1, -1
+cv.or.sci.h s0, s1, 63
+# CHECK-INSTR: cv.or.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0x5b]
 
 //===----------------------------------------------------------------------===//
 // cv.or.sci.b
 //===----------------------------------------------------------------------===//
 
-cv.or.sci.b t0, t1, -32
-# CHECK-INSTR: cv.or.sci.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x72,0x03,0x59]
+cv.or.sci.b t0, t1, 0
+# CHECK-INSTR: cv.or.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x58]
+
+cv.or.sci.b t3, t4, 32
+# CHECK-INSTR: cv.or.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x59]
 
 cv.or.sci.b a0, a1, 7
 # CHECK-INSTR: cv.or.sci.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xf5,0x35,0x5a]
 
-cv.or.sci.b s0, s1, -1
-# CHECK-INSTR: cv.or.sci.b s0, s1, -1
+cv.or.sci.b s0, s1, 63
+# CHECK-INSTR: cv.or.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0x5b]
 

--- a/llvm/test/MC/RISCV/corev/simd/xor-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/xor-invalid.s
@@ -100,13 +100,16 @@ cv.xor.sci.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.sci.h t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.xor.sci.h t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.xor.sci.h t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.xor.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.xor.sci.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -122,13 +125,16 @@ cv.xor.sci.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.sci.b t0, t1, t2, t3
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.xor.sci.b t0, t1, t2
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
-cv.xor.sci.b t0, t1, 63
-# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+cv.xor.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
 
 cv.xor.sci.b t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/simd/xor.s
+++ b/llvm/test/MC/RISCV/corev/simd/xor.s
@@ -9,6 +9,10 @@ cv.xor.h t0, t1, t2
 # CHECK-INSTR: cv.xor.h t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x02,0x73,0x60]
 
+cv.xor.h t3, t4, t5
+# CHECK-INSTR: cv.xor.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x61]
+
 cv.xor.h a0, a1, a2
 # CHECK-INSTR: cv.xor.h a0, a1, a2
 # CHECK-ENCODING: [0x7b,0x85,0xc5,0x60]
@@ -24,6 +28,10 @@ cv.xor.h s0, s1, s2
 cv.xor.b t0, t1, t2
 # CHECK-INSTR: cv.xor.b t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x12,0x73,0x60]
+
+cv.xor.b t3, t4, t5
+# CHECK-INSTR: cv.xor.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x61]
 
 cv.xor.b a0, a1, a2
 # CHECK-INSTR: cv.xor.b a0, a1, a2
@@ -41,6 +49,10 @@ cv.xor.sc.h t0, t1, t2
 # CHECK-INSTR: cv.xor.sc.h t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x42,0x73,0x60]
 
+cv.xor.sc.h t3, t4, t5
+# CHECK-INSTR: cv.xor.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x61]
+
 cv.xor.sc.h a0, a1, a2
 # CHECK-INSTR: cv.xor.sc.h a0, a1, a2
 # CHECK-ENCODING: [0x7b,0xc5,0xc5,0x60]
@@ -57,6 +69,10 @@ cv.xor.sc.b t0, t1, t2
 # CHECK-INSTR: cv.xor.sc.b t0, t1, t2
 # CHECK-ENCODING: [0xfb,0x52,0x73,0x60]
 
+cv.xor.sc.b t3, t4, t5
+# CHECK-INSTR: cv.xor.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x61]
+
 cv.xor.sc.b a0, a1, a2
 # CHECK-INSTR: cv.xor.sc.b a0, a1, a2
 # CHECK-ENCODING: [0x7b,0xd5,0xc5,0x60]
@@ -69,31 +85,39 @@ cv.xor.sc.b s0, s1, s2
 // cv.xor.sci.h
 //===----------------------------------------------------------------------===//
 
-cv.xor.sci.h t0, t1, -32
-# CHECK-INSTR: cv.xor.sci.h t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x62,0x03,0x61]
+cv.xor.sci.h t0, t1, 0
+# CHECK-INSTR: cv.xor.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x60]
+
+cv.xor.sci.h t3, t4, 32
+# CHECK-INSTR: cv.xor.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x61]
 
 cv.xor.sci.h a0, a1, 7
 # CHECK-INSTR: cv.xor.sci.h a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xe5,0x35,0x62]
 
-cv.xor.sci.h s0, s1, -1
-# CHECK-INSTR: cv.xor.sci.h s0, s1, -1
+cv.xor.sci.h s0, s1, 63
+# CHECK-INSTR: cv.xor.sci.h s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xe4,0xf4,0x63]
 
 //===----------------------------------------------------------------------===//
 // cv.xor.sci.b
 //===----------------------------------------------------------------------===//
 
-cv.xor.sci.b t0, t1, -32
-# CHECK-INSTR: cv.xor.sci.b t0, t1, -32
-# CHECK-ENCODING: [0xfb,0x72,0x03,0x61]
+cv.xor.sci.b t0, t1, 0
+# CHECK-INSTR: cv.xor.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x60]
+
+cv.xor.sci.b t3, t4, 32
+# CHECK-INSTR: cv.xor.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x61]
 
 cv.xor.sci.b a0, a1, 7
 # CHECK-INSTR: cv.xor.sci.b a0, a1, 7
 # CHECK-ENCODING: [0x7b,0xf5,0x35,0x62]
 
-cv.xor.sci.b s0, s1, -1
-# CHECK-INSTR: cv.xor.sci.b s0, s1, -1
+cv.xor.sci.b s0, s1, 63
+# CHECK-INSTR: cv.xor.sci.b s0, s1, 63
 # CHECK-ENCODING: [0x7b,0xf4,0xf4,0x63]
 


### PR DESCRIPTION
The and/or/xor/extract/insert/extractu instructions are changed to be unsigned, mirroring the change in https://github.com/openhwgroup/corev-binutils-gdb/pull/91