### PR TITLE
[RISCV] Update Xcvmac Pseudo Instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -336,14 +336,6 @@ let Predicates = [HasExtXcvsimd], hasSideEffects = 0, mayLoad = 0, mayStore = 0 
 }
 
 let Predicates = [HasExtXcvmac], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
-  // Signed 16x16 bit muls
-  def CV_MULS     : RVInstMac16<0b10, 0b000, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2),
-                                "cv.muls", "$rd, $rs1, $rs2", []>,
-                    Sched<[]>;
-  def CV_MULHHS   : RVInstMac16<0b11, 0b000, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2),
-                                "cv.mulhhs", "$rd, $rs1, $rs2", []>,
-                    Sched<[]>;
-
   // Signed 16x16 bit muls with imm
   def CV_MULSN    : RVInstMac16I<0b00, 0b100, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2, uimm5:$imm5),
                                  "cv.mulsn", "$rd, $rs1, $rs2, $imm5", []>,
@@ -358,13 +350,6 @@ let Predicates = [HasExtXcvmac], hasSideEffects = 0, mayLoad = 0, mayStore = 0 i
                                  "cv.mulhhsrn", "$rd, $rs1, $rs2, $imm5", []>,
                     Sched<[]>;
 
-  // Unsigned 16x16 bit muls
-  def CV_MULU     : RVInstMac16<0b00, 0b000, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2),
-                                "cv.mulu", "$rd, $rs1, $rs2", []>,
-                    Sched<[]>;
-  def CV_MULHHU   : RVInstMac16<0b01, 0b000, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2),
-                                "cv.mulhhu", "$rd, $rs1, $rs2", []>,
-                    Sched<[]>;
 
   // Unsigned 16x16 bit muls with imm
   def CV_MULUN    : RVInstMac16I<0b00, 0b101, (outs GPR:$rd), (ins GPR:$rs1, GPR:$rs2, uimm5:$imm5),
@@ -380,6 +365,17 @@ let Predicates = [HasExtXcvmac], hasSideEffects = 0, mayLoad = 0, mayStore = 0 i
                                  "cv.mulhhurn", "$rd, $rs1, $rs2, $imm5", []>,
                     Sched<[]>;
 } // Predicates = [HasExtXcvmac], hasSideEffects = 0, mayLoad = 0, mayStore = 0
+
+let Predicates = [HasExtXcvmac] in {
+  // Xcvmac Pseudo Instructions
+  // Signed 16x16 bit muls
+  def : InstAlias<"cv.muls $rd1, $rs1, $rs2", (CV_MULSN GPR:$rd1, GPR:$rs1, GPR:$rs2, 0), 0>;
+  def : InstAlias<"cv.mulhhs $rd1, $rs1, $rs2", (CV_MULHHSN GPR:$rd1, GPR:$rs1, GPR:$rs2, 0), 0>;
+
+  // Unsigned 16x16 bit muls
+  def : InstAlias<"cv.mulu $rd1, $rs1, $rs2", (CV_MULUN GPR:$rd1, GPR:$rs1, GPR:$rs2, 0), 0>;
+  def : InstAlias<"cv.mulhhu $rd1, $rs1, $rs2", (CV_MULHHUN GPR:$rd1, GPR:$rs1, GPR:$rs2, 0), 0>;
+} // Predicates = [HasExtXcvmac]
 
 let Predicates = [HasExtXcvalu], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
   // General ALU Operations
@@ -725,9 +721,9 @@ let Predicates = [HasExtXcvmac] in {
             (CV_MSU GPR:$rd, GPR:$rs1, GPR:$rs2)>;
 
   def : Pat<(muls GPR:$rs1, GPR:$rs2),
-            (CV_MULS GPR:$rs1, GPR:$rs2)>;
+            (CV_MULSN GPR:$rs1, GPR:$rs2, 0)>;
   def : Pat<(mulhhs GPR:$rs1, GPR:$rs2),
-            (CV_MULHHS GPR:$rs1, GPR:$rs2)>;
+            (CV_MULHHSN GPR:$rs1, GPR:$rs2, 0)>;
   def : Pat<(sra (muls GPR:$rs1, GPR:$rs2), uimm5:$imm5),
             (CV_MULSN GPR:$rs1, GPR:$rs2, uimm5:$imm5)>;
   def : Pat<(sra (mulhhs GPR:$rs1, GPR:$rs2), uimm5:$imm5),
@@ -738,9 +734,9 @@ let Predicates = [HasExtXcvmac] in {
             (CV_MULHHSRN GPR:$rs1, GPR:$rs2, uimm5:$imm5)>;
 
   def : Pat<(mulu GPR:$rs1, GPR:$rs2),
-            (CV_MULU GPR:$rs1, GPR:$rs2)>;
+            (CV_MULUN GPR:$rs1, GPR:$rs2, 0)>;
   def : Pat<(mulhhu GPR:$rs1, GPR:$rs2),
-            (CV_MULHHU GPR:$rs1, GPR:$rs2)>;
+            (CV_MULHHUN GPR:$rs1, GPR:$rs2, 0)>;
   def : Pat<(srl (mulu GPR:$rs1, GPR:$rs2), uimm5:$imm5),
             (CV_MULUN GPR:$rs1, GPR:$rs2, uimm5:$imm5)>;
   def : Pat<(srl (mulhhu GPR:$rs1, GPR:$rs2), uimm5:$imm5),

--- a/llvm/test/CodeGen/RISCV/corev/mac.ll
+++ b/llvm/test/CodeGen/RISCV/corev/mac.ll
@@ -31,7 +31,7 @@ define i32 @muls(i32 %a, i32 %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    slli a0, a0, 16
 ; CHECK-NEXT:    slli a1, a1, 16
-; CHECK-NEXT:    cv.mulhhs a0, a0, a1
+; CHECK-NEXT:    cv.mulhhsn a0, a0, a1, 0
 ; CHECK-NEXT:    ret
   %1 = shl i32 %a, 16
   %2 = ashr i32 %1, 16
@@ -44,7 +44,7 @@ define i32 @muls(i32 %a, i32 %b) {
 define i32 @mulhhs(i32 %a, i32 %b) {
 ; CHECK-LABEL: mulhhs:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.mulhhs a0, a0, a1
+; CHECK-NEXT:    cv.mulhhsn a0, a0, a1, 0
 ; CHECK-NEXT:    ret
   %1 = ashr i32 %a, 16
   %2 = ashr i32 %b, 16
@@ -113,7 +113,7 @@ define i32 @mulhhsRN(i32 %a, i32 %b) {
 define i32 @mulu(i32 %a, i32 %b) {
 ; CHECK-LABEL: mulu:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.mulu a0, a0, a1
+; CHECK-NEXT:    cv.mulun a0, a0, a1, 0
 ; CHECK-NEXT:    ret
   %1 = and i32 %a, 65535
   %2 = and i32 %b, 65535
@@ -124,7 +124,7 @@ define i32 @mulu(i32 %a, i32 %b) {
 define i32 @mulhhu(i32 %a, i32 %b) {
 ; CHECK-LABEL: mulhhu:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.mulhhu a0, a0, a1
+; CHECK-NEXT:    cv.mulhhun a0, a0, a1, 0
 ; CHECK-NEXT:    ret
   %1 = lshr i32 %a, 16
   %2 = lshr i32 %b, 16
@@ -135,7 +135,7 @@ define i32 @mulhhu(i32 %a, i32 %b) {
 define i32 @muluN(i32 %a, i32 %b) {
 ; CHECK-LABEL: muluN:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.mulu a0, a0, a1
+; CHECK-NEXT:    cv.mulun a0, a0, a1, 0
 ; CHECK-NEXT:    srai a0, a0, 5
 ; CHECK-NEXT:    ret
   %1 = and i32 %a, 65535

--- a/llvm/test/MC/RISCV/corev/mac-all-extensions.s
+++ b/llvm/test/MC/RISCV/corev/mac-all-extensions.s
@@ -16,12 +16,12 @@ cv.msu t0, t1, t2
 # 16x16 bit MUL instructions
 
 cv.muls t0, t1, t2
-# CHECK-INSTR: cv.muls t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0x80]
+# CHECK-INSTR: cv.mulsn t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x42,0x73,0x00]
 
 cv.mulhhs t0, t1, t2
-# CHECK-INSTR: cv.mulhhs t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0xc0]
+# CHECK-INSTR: cv.mulhhsn t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x42,0x73,0x40]
 
 cv.mulsn t0, t1, t2, 0
 # CHECK-INSTR: cv.mulsn t0, t1, t2, 0
@@ -40,12 +40,12 @@ cv.mulhhsrn t0, t1, t2, 0
 # CHECK-ENCODING: [0xdb,0x42,0x73,0xc0]
 
 cv.mulu t0, t1, t2
-# CHECK-INSTR: cv.mulu t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0x00]
+# CHECK-INSTR: cv.mulun t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x52,0x73,0x00]
 
 cv.mulhhu t0, t1, t2
-# CHECK-INSTR: cv.mulhhu t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0x40]
+# CHECK-INSTR: cv.mulhhun t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x52,0x73,0x40]
 
 cv.mulun t0, t1, t2, 0
 # CHECK-INSTR: cv.mulun t0, t1, t2, 0

--- a/llvm/test/MC/RISCV/corev/mac/mulhhs.s
+++ b/llvm/test/MC/RISCV/corev/mac/mulhhs.s
@@ -2,9 +2,9 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
 cv.mulhhs t0, t1, t2
-# CHECK-INSTR: cv.mulhhs t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0xc0]
+# CHECK-INSTR: cv.mulhhsn t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x42,0x73,0x40]
 
 cv.mulhhs t0, t1, zero
-# CHECK-INSTR: cv.mulhhs t0, t1, zero
-# CHECK-ENCODING: [0xdb,0x02,0x03,0xc0]
+# CHECK-INSTR: cv.mulhhsn t0, t1, zero, 0
+# CHECK-ENCODING: [0xdb,0x42,0x03,0x40]

--- a/llvm/test/MC/RISCV/corev/mac/mulhhu.s
+++ b/llvm/test/MC/RISCV/corev/mac/mulhhu.s
@@ -2,9 +2,9 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
 cv.mulhhu t0, t1, t2
-# CHECK-INSTR: cv.mulhhu t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0x40]
+# CHECK-INSTR: cv.mulhhun t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x52,0x73,0x40]
 
 cv.mulhhu t0, t1, zero
-# CHECK-INSTR: cv.mulhhu t0, t1, zero
-# CHECK-ENCODING: [0xdb,0x02,0x03,0x40]
+# CHECK-INSTR: cv.mulhhun t0, t1, zero, 0
+# CHECK-ENCODING: [0xdb,0x52,0x03,0x40]

--- a/llvm/test/MC/RISCV/corev/mac/muls.s
+++ b/llvm/test/MC/RISCV/corev/mac/muls.s
@@ -2,9 +2,9 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
 cv.muls t0, t1, t2
-# CHECK-INSTR: cv.muls t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0x80]
+# CHECK-INSTR: cv.mulsn t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x42,0x73,0x00]
 
 cv.muls t0, t1, zero
-# CHECK-INSTR: cv.muls t0, t1, zero
-# CHECK-ENCODING: [0xdb,0x02,0x03,0x80]
+# CHECK-INSTR: cv.mulsn t0, t1, zero, 0
+# CHECK-ENCODING: [0xdb,0x42,0x03,0x00]

--- a/llvm/test/MC/RISCV/corev/mac/mulu.s
+++ b/llvm/test/MC/RISCV/corev/mac/mulu.s
@@ -2,9 +2,9 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
 cv.mulu t0, t1, t2
-# CHECK-INSTR: cv.mulu t0, t1, t2
-# CHECK-ENCODING: [0xdb,0x02,0x73,0x00]
+# CHECK-INSTR: cv.mulun t0, t1, t2, 0
+# CHECK-ENCODING: [0xdb,0x52,0x73,0x00]
 
 cv.mulu t0, t1, zero
-# CHECK-INSTR: cv.mulu t0, t1, zero
-# CHECK-ENCODING: [0xdb,0x02,0x03,0x00]
+# CHECK-INSTR: cv.mulun t0, t1, zero, 0
+# CHECK-ENCODING: [0xdb,0x52,0x03,0x00]


### PR DESCRIPTION
Map `cv.mul* rd1, rs1, rs2` to `cv.mul*n rd1, rs1, rs2, 0` to match the behavior in GCC.

See [commit in binutils](https://github.com/openhwgroup/corev-binutils-gdb/commit/fb057860b79ede6511ce57dde982c00903bb8a54)