### PR TITLE
Fix xcvmem heuristic

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1010,7 +1010,7 @@ unsigned RISCVTTIImpl::getMaximumVF(unsigned ElemWidth, unsigned Opcode) const {
 
 TTI::AddressingModeKind
 RISCVTTIImpl::getPreferredAddressingMode(const Loop *L,
-                                       ScalarEvolution *SE) const {
+                                         ScalarEvolution *SE) const {
   if (ST->hasExtXcvmem())
     return TTI::AMK_PostIndexed;
 

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1008,10 +1008,6 @@ unsigned RISCVTTIImpl::getMaximumVF(unsigned ElemWidth, unsigned Opcode) const {
   return SLPMaxVF;
 }
 
-bool RISCVTTIImpl::shouldFavorPostInc() const {
-  return ST->hasExtXcvmem();
-}
-
 TTI::AddressingModeKind
 RISCVTTIImpl::getPreferredAddressingMode(const Loop *L,
                                        ScalarEvolution *SE) const {

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1012,6 +1012,15 @@ bool RISCVTTIImpl::shouldFavorPostInc() const {
   return ST->hasExtXcvmem();
 }
 
+TTI::AddressingModeKind
+RISCVTTIImpl::getPreferredAddressingMode(const Loop *L,
+                                       ScalarEvolution *SE) const {
+  if (ST->hasExtXcvmem())
+    return TTI::AMK_PostIndexed;
+
+  return TTI::AMK_None;
+}
+
 bool RISCVTTIImpl::isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
                                             AssumptionCache &AC,
                                             TargetLibraryInfo *LibInfo,

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -309,8 +309,8 @@ public:
     llvm_unreachable("unknown register class");
   }
 
-  TTI::AddressingModeKind
-    getPreferredAddressingMode(const Loop *L, ScalarEvolution *SE) const;
+  TTI::AddressingModeKind getPreferredAddressingMode(const Loop *L,
+                                                     ScalarEvolution *SE) const;
 
   bool isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
                                 AssumptionCache &AC,

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -309,7 +309,6 @@ public:
     llvm_unreachable("unknown register class");
   }
 
-  bool shouldFavorPostInc() const;
   TTI::AddressingModeKind
     getPreferredAddressingMode(const Loop *L, ScalarEvolution *SE) const;
 

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -308,8 +308,11 @@ public:
     }
     llvm_unreachable("unknown register class");
   }
-  
+
   bool shouldFavorPostInc() const;
+  TTI::AddressingModeKind
+    getPreferredAddressingMode(const Loop *L, ScalarEvolution *SE) const;
+
   bool isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
                                 AssumptionCache &AC,
                                 TargetLibraryInfo *LibInfo,


### PR DESCRIPTION
The original heuristic `shouldFavorPostInc` was replaced with `getPreferredAddressingMode` in https://reviews.llvm.org/D96600.

Please let me know whether adding a unit test for this functionality is feasible.