### PR TITLE
Subtarget for the CV32E40P and respective tests

### DIFF
--- a/clang/test/Driver/riscv-cpus.c
+++ b/clang/test/Driver/riscv-cpus.c
@@ -26,8 +26,8 @@
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=rocket | FileCheck -check-prefix=MTUNE-ROCKET-64 %s
 // MTUNE-ROCKET-64: "-tune-cpu" "rocket"
 
-// RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=CV32E40P | FileCheck -check-prefix=MCPU-CV32E40P %s
-// MCPU-CV32E40P: "-target-cpu" "CV32E40P"
+// RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=cv32e40p | FileCheck -check-prefix=MCPU-CV32E40P %s
+// MCPU-CV32E40P: "-target-cpu" "cv32e40p"
 // MCPU-CV32E40P: "-target-feature" "+m" "-target-feature" "+f" "-target-feature" "+c" "-target-feature" "-64bit"
 // MCPU-CV32E40P: "-target-abi" "ilp32"
 

--- a/clang/test/Driver/riscv-cpus.c
+++ b/clang/test/Driver/riscv-cpus.c
@@ -26,6 +26,11 @@
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=rocket | FileCheck -check-prefix=MTUNE-ROCKET-64 %s
 // MTUNE-ROCKET-64: "-tune-cpu" "rocket"
 
+// RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=CV32E40P | FileCheck -check-prefix=MCPU-CV32E40P %s
+// MCPU-CV32E40P: "-target-cpu" "CV32E40P"
+// MCPU-CV32E40P: "-target-feature" "+m" "-target-feature" "+f" "-target-feature" "+c" "-target-feature" "-64bit"
+// MCPU-CV32E40P: "-target-abi" "ilp32"
+
 // mcpu with default march
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mcpu=sifive-e20 | FileCheck -check-prefix=MCPU-SIFIVE-E20 %s
 // MCPU-SIFIVE-E20: "-nostdsysteminc" "-target-cpu" "sifive-e20"

--- a/clang/test/Misc/target-invalid-cpu-note.c
+++ b/clang/test/Misc/target-invalid-cpu-note.c
@@ -81,7 +81,7 @@
 
 // RUN: not %clang_cc1 -triple riscv32 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV32
 // RISCV32: error: unknown target CPU 'not-a-cpu'
-// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76{{$}}
+// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, CV32E40P{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV64
 // RISCV64: error: unknown target CPU 'not-a-cpu'
@@ -89,7 +89,7 @@
 
 // RUN: not %clang_cc1 -triple riscv32 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV32
 // TUNE-RISCV32: error: unknown target CPU 'not-a-cpu'
-// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, generic, rocket, sifive-7-series{{$}}
+// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, CV32E40P, generic, rocket, sifive-7-series{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV64
 // TUNE-RISCV64: error: unknown target CPU 'not-a-cpu'

--- a/clang/test/Misc/target-invalid-cpu-note.c
+++ b/clang/test/Misc/target-invalid-cpu-note.c
@@ -81,7 +81,7 @@
 
 // RUN: not %clang_cc1 -triple riscv32 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV32
 // RISCV32: error: unknown target CPU 'not-a-cpu'
-// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, CV32E40P{{$}}
+// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, cv32e40p, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV64
 // RISCV64: error: unknown target CPU 'not-a-cpu'
@@ -89,7 +89,7 @@
 
 // RUN: not %clang_cc1 -triple riscv32 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV32
 // TUNE-RISCV32: error: unknown target CPU 'not-a-cpu'
-// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, CV32E40P, generic, rocket, sifive-7-series{{$}}
+// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, cv32e40p, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, generic, rocket, sifive-7-series{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV64
 // TUNE-RISCV64: error: unknown target CPU 'not-a-cpu'

--- a/llvm/include/llvm/Support/RISCVTargetParser.def
+++ b/llvm/include/llvm/Support/RISCVTargetParser.def
@@ -19,6 +19,7 @@ PROC(SIFIVE_S54, {"sifive-s54"}, FK_64BIT, {"rv64gc"})
 PROC(SIFIVE_S76, {"sifive-s76"}, FK_64BIT, {"rv64gc"})
 PROC(SIFIVE_U54, {"sifive-u54"}, FK_64BIT, {"rv64gc"})
 PROC(SIFIVE_U74, {"sifive-u74"}, FK_64BIT, {"rv64gc"})
+PROC(CV32E40P, {"CV32E40P"}, FK_NONE, {"rv32imfc"})
 
 #undef PROC
 

--- a/llvm/include/llvm/Support/RISCVTargetParser.def
+++ b/llvm/include/llvm/Support/RISCVTargetParser.def
@@ -5,6 +5,7 @@
 PROC(INVALID, {"invalid"}, FK_INVALID, {""})
 PROC(GENERIC_RV32, {"generic-rv32"}, FK_NONE, {""})
 PROC(GENERIC_RV64, {"generic-rv64"}, FK_64BIT, {""})
+PROC(CV32E40P, {"cv32e40p"}, FK_NONE, {"rv32imfc"})
 PROC(ROCKET_RV32, {"rocket-rv32"}, FK_NONE, {""})
 PROC(ROCKET_RV64, {"rocket-rv64"}, FK_64BIT, {""})
 PROC(SIFIVE_E20, {"sifive-e20"}, FK_NONE, {"rv32imc"})
@@ -19,7 +20,6 @@ PROC(SIFIVE_S54, {"sifive-s54"}, FK_64BIT, {"rv64gc"})
 PROC(SIFIVE_S76, {"sifive-s76"}, FK_64BIT, {"rv64gc"})
 PROC(SIFIVE_U54, {"sifive-u54"}, FK_64BIT, {"rv64gc"})
 PROC(SIFIVE_U74, {"sifive-u74"}, FK_64BIT, {"rv64gc"})
-PROC(CV32E40P, {"CV32E40P"}, FK_NONE, {"rv32imfc"})
 
 #undef PROC
 

--- a/llvm/lib/Target/RISCV/RISCV.td
+++ b/llvm/lib/Target/RISCV/RISCV.td
@@ -565,7 +565,7 @@ include "RISCVInstrInfo.td"
 include "RISCVRegisterBanks.td"
 include "RISCVSchedRocket.td"
 include "RISCVSchedSiFive7.td"
-include "RISCVSchedCV32E40P.td"
+include "RISCVSchedcv32e40p.td"
 
 //===----------------------------------------------------------------------===//
 // RISC-V processors supported.
@@ -657,7 +657,7 @@ def : ProcessorModel<"sifive-u74", SiFive7Model, [Feature64Bit,
                                                   FeatureStdExtC],
                      [TuneSiFive7]>;
 
-def : ProcessorModel<"CV32E40P", CV32E40PModel, [Feature32Bit,
+def : ProcessorModel<"cv32e40p", cv32e40pModel, [Feature32Bit,
                                                  FeatureStdExtM,
                                                  FeatureStdExtF,
                                                  FeatureStdExtC],

--- a/llvm/lib/Target/RISCV/RISCV.td
+++ b/llvm/lib/Target/RISCV/RISCV.td
@@ -565,6 +565,7 @@ include "RISCVInstrInfo.td"
 include "RISCVRegisterBanks.td"
 include "RISCVSchedRocket.td"
 include "RISCVSchedSiFive7.td"
+include "RISCVSchedCV32E40P.td"
 
 //===----------------------------------------------------------------------===//
 // RISC-V processors supported.
@@ -655,6 +656,12 @@ def : ProcessorModel<"sifive-u74", SiFive7Model, [Feature64Bit,
                                                   FeatureStdExtD,
                                                   FeatureStdExtC],
                      [TuneSiFive7]>;
+
+def : ProcessorModel<"CV32E40P", CV32E40PModel, [Feature32Bit,
+                                                 FeatureStdExtM,
+                                                 FeatureStdExtF,
+                                                 FeatureStdExtC],
+                    [TuneNoDefaultUnroll]>;
 
 //===----------------------------------------------------------------------===//
 // Define the RISC-V target.

--- a/llvm/lib/Target/RISCV/RISCVSchedCV32E40P.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedCV32E40P.td
@@ -1,0 +1,222 @@
+// ===---------------------------------------------------------------------===//
+
+def CV32E40PModel : SchedMachineModel {
+  let MicroOpBufferSize = 0; // CV32E40P is in-order.
+  let IssueWidth = 1;        
+  let LoadLatency = 1;          
+  let MispredictPenalty = 3;
+  let CompleteModel = false;
+  let UnsupportedFeatures = [HasStdExtA, HasAtomicLdSt,
+                             HasStdExtZfinx, HasStdExtCOrZca,
+                             HasStdExtZbkb, HasStdExtZbkc, HasStdExtZbkx,
+                             HasStdExtZknd, HasStdExtZkne,
+                             HasStdExtZknh, HasStdExtZksed, HasStdExtZksh,
+                             HasStdExtZkr, HasVInstructions, HasVInstructionsI64];
+}
+
+// ===---------------------------------------------------------------------===//
+
+let BufferSize = 0 in {     
+def CV32E40PUnitLSU         : ProcResource<1>; // Load/Store
+def CV32E40PUnitBranch      : ProcResource<1>; // Branch/JumpDecoder
+def CV32E40PUnitALU         : ProcResource<1>; // ALU
+def CV32E40PUnitMul         : ProcResource<1>; // Multiply
+def CV32E40PUnitDiv         : ProcResource<1>; // Division
+def CV32E40PUnitFPU         : ProcResource<1>; // Optional FPU 
+def CV32E40PUnitCSR         : ProcResource<1>; // CSR
+} 
+
+
+//===----------------------------------------------------------------------===//
+
+let SchedModel = CV32E40PModel in {
+
+// ALU
+def : WriteRes<WriteIALU, [CV32E40PUnitALU]>;
+def : WriteRes<WriteShiftImm, [CV32E40PUnitALU]>;
+def : WriteRes<WriteShiftReg, [CV32E40PUnitALU]>;
+
+// Store (sb, sh, sw), assuming they are word aligned
+def : WriteRes<WriteSTB, [CV32E40PUnitLSU]>; // sb
+def : WriteRes<WriteSTH, [CV32E40PUnitLSU]>; // sh
+def : WriteRes<WriteSTW, [CV32E40PUnitLSU]>; // sw
+
+// Load (lh, lw, lbu, lhu), assuming they are word aligned
+def : WriteRes<WriteLDH, [CV32E40PUnitLSU]>; // lh, lhu
+def : WriteRes<WriteLDW, [CV32E40PUnitLSU]>; // lw
+def : WriteRes<WriteLDWU, [CV32E40PUnitLSU]>;
+def : WriteRes<WriteLDB, [CV32E40PUnitLSU]>; // lbu
+
+// Jump instructions, assuming jumps are word alligned
+let Latency = 2 in {
+  def : WriteRes<WriteJmp, [CV32E40PUnitBranch]>;
+  def : WriteRes<WriteJal, [CV32E40PUnitBranch]>;
+  def : WriteRes<WriteJalr, [CV32E40PUnitBranch]>;
+  def : WriteRes<WriteJmpReg, [CV32E40PUnitBranch]>;
+}
+
+// mul has a latency of 1 cycle, 
+// mulh, mulhsu, mulhu take 5 cycles but RISCVSchedule.td
+// does not provide a seperate scheduler resource for those instructions
+// assuming that the majority of multiplications take 1 cycle
+def : WriteRes<WriteIMul, [CV32E40PUnitMul]>;
+
+// Division and remainder, assuming worst case latency
+def : WriteRes<WriteIDiv, [CV32E40PUnitDiv]> {
+  let Latency = 35;
+  let ResourceCycles = [35];
+}
+
+// 32 bit floating point operations
+// assuming worst case latency
+def : WriteRes<WriteFST32, [CV32E40PUnitLSU]>;
+def : WriteRes<WriteFLD32, [CV32E40PUnitLSU]>;
+let Latency = 11 in {
+  def : WriteRes<WriteFAdd32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFSGNJ32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFMinMax32, [CV32E40PUnitFPU]>;
+  // conversions
+  def : WriteRes<WriteFCvtI32ToF32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFCvtI64ToF32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFCvtF32ToI32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFCvtF32ToI64, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFMovF32ToI32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFMovI32ToF32, [CV32E40PUnitFPU]>;
+
+  def : WriteRes<WriteFCmp32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFClass32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFMul32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFMA32, [CV32E40PUnitFPU]>;
+}
+// Single Precision Floating-Point Division and Square-Root
+let Latency = 12 in {
+  def : WriteRes<WriteFDiv32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFSqrt32, [CV32E40PUnitFPU]>;
+}
+
+
+
+
+let Unsupported = true in {
+  // RV64I
+  def : WriteRes<WriteIALU32, []>;
+  def : WriteRes<WriteShiftImm32, []>;
+  def : WriteRes<WriteShiftReg32, []>;
+  def : WriteRes<WriteIDiv32, []>; 
+  def : WriteRes<WriteIMul32, []>;
+  def : WriteRes<WriteLDD, []>;
+  def : WriteRes<WriteSTD, []>;
+
+  // Atomic memory
+  def : WriteRes<WriteAtomicW, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteAtomicD, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteAtomicLDW, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteAtomicLDD, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteAtomicSTW, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteAtomicSTD, [CV32E40PUnitLSU]>;
+
+  // 64 bit FP load/store
+  def : WriteRes<WriteFST64, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteFLD64, [CV32E40PUnitLSU]>;
+
+  // 64 bit FP instructions 
+  def : WriteRes<WriteFAdd64, []>;
+  def : WriteRes<WriteFSGNJ64, []>;
+  def : WriteRes<WriteFMinMax64, []>;
+  def : WriteRes<WriteFCvtI32ToF64, []>;
+  def : WriteRes<WriteFCvtI64ToF64, []>;
+  def : WriteRes<WriteFCvtF64ToI32, []>;
+  def : WriteRes<WriteFCvtF64ToI64, []>;
+  def : WriteRes<WriteFCvtF32ToF64, []>;
+  def : WriteRes<WriteFCvtF64ToF32, []>;
+  def : WriteRes<WriteFClass64, []>;
+  def : WriteRes<WriteFCmp64, []>;
+  def : WriteRes<WriteFMovF64ToI64, []>;
+  def : WriteRes<WriteFMovI64ToF64, []>;
+  def : WriteRes<WriteFMul64, []>;
+  def : WriteRes<WriteFMA64, []>;
+  def : WriteRes<WriteFDiv64, []>;
+  def : WriteRes<WriteFSqrt64, []>;
+} // Unsupported
+
+// Others
+// assuming the worst case latency for CSR access
+// as there are no scheduler resources to differentiate them
+def : WriteRes<WriteCSR, [CV32E40PUnitCSR]> {
+  let Latency = 4;
+}
+def : WriteRes<WriteNop, []>;
+
+//===----------------------------------------------------------------------===//
+// Bypass and advance
+// CV32E40P has no forwarding 
+def : ReadAdvance<ReadJmp, 0>;
+def : ReadAdvance<ReadJalr, 0>;
+def : ReadAdvance<ReadCSR, 0>;
+def : ReadAdvance<ReadStoreData, 0>;
+def : ReadAdvance<ReadMemBase, 0>;
+def : ReadAdvance<ReadIALU, 0>;
+def : ReadAdvance<ReadIALU32, 0>;
+def : ReadAdvance<ReadShiftImm, 0>;
+def : ReadAdvance<ReadShiftImm32, 0>;
+def : ReadAdvance<ReadShiftReg, 0>;
+def : ReadAdvance<ReadShiftReg32, 0>;
+def : ReadAdvance<ReadIDiv, 0>;
+def : ReadAdvance<ReadIDiv32, 0>;
+def : ReadAdvance<ReadIMul, 0>;
+def : ReadAdvance<ReadIMul32, 0>;
+def : ReadAdvance<ReadAtomicWA, 0>;
+def : ReadAdvance<ReadAtomicWD, 0>;
+def : ReadAdvance<ReadAtomicDA, 0>;
+def : ReadAdvance<ReadAtomicDD, 0>;
+def : ReadAdvance<ReadAtomicLDW, 0>;
+def : ReadAdvance<ReadAtomicLDD, 0>;
+def : ReadAdvance<ReadAtomicSTW, 0>;
+def : ReadAdvance<ReadAtomicSTD, 0>;
+def : ReadAdvance<ReadFStoreData, 0>;
+def : ReadAdvance<ReadFMemBase, 0>;
+def : ReadAdvance<ReadFAdd32, 0>;
+def : ReadAdvance<ReadFAdd64, 0>;
+def : ReadAdvance<ReadFMul32, 0>;
+def : ReadAdvance<ReadFMul64, 0>;
+def : ReadAdvance<ReadFMA32, 0>;
+def : ReadAdvance<ReadFMA64, 0>;
+def : ReadAdvance<ReadFDiv32, 0>;
+def : ReadAdvance<ReadFDiv64, 0>;
+def : ReadAdvance<ReadFSqrt32, 0>;
+def : ReadAdvance<ReadFSqrt64, 0>;
+def : ReadAdvance<ReadFCmp32, 0>;
+def : ReadAdvance<ReadFCmp64, 0>;
+def : ReadAdvance<ReadFSGNJ32, 0>;
+def : ReadAdvance<ReadFSGNJ64, 0>;
+def : ReadAdvance<ReadFMinMax32, 0>;
+def : ReadAdvance<ReadFMinMax64, 0>;
+def : ReadAdvance<ReadFCvtF32ToI32, 0>;
+def : ReadAdvance<ReadFCvtF32ToI64, 0>;
+def : ReadAdvance<ReadFCvtF64ToI32, 0>;
+def : ReadAdvance<ReadFCvtF64ToI64, 0>;
+def : ReadAdvance<ReadFCvtI32ToF32, 0>;
+def : ReadAdvance<ReadFCvtI32ToF64, 0>;
+def : ReadAdvance<ReadFCvtI64ToF32, 0>;
+def : ReadAdvance<ReadFCvtI64ToF64, 0>;
+def : ReadAdvance<ReadFCvtF32ToF64, 0>;
+def : ReadAdvance<ReadFCvtF64ToF32, 0>;
+def : ReadAdvance<ReadFMovF32ToI32, 0>;
+def : ReadAdvance<ReadFMovI32ToF32, 0>;
+def : ReadAdvance<ReadFMovF64ToI64, 0>;
+def : ReadAdvance<ReadFMovI64ToF64, 0>;
+def : ReadAdvance<ReadFClass32, 0>;
+def : ReadAdvance<ReadFClass64, 0>;
+
+//===----------------------------------------------------------------------===//
+// Unsupported extensions
+defm : UnsupportedSchedV;
+defm : UnsupportedSchedZba;
+defm : UnsupportedSchedZbb;
+defm : UnsupportedSchedZbc;
+defm : UnsupportedSchedZbs;
+defm : UnsupportedSchedZbkb;
+defm : UnsupportedSchedZbkx;
+defm : UnsupportedSchedZfh;
+defm : UnsupportedSchedSFB;
+}

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -153,7 +153,7 @@ def : WriteRes<WriteNop, []>;
 //===----------------------------------------------------------------------===//
 // ReadAdvance definitions
 def : ReadAdvance<ReadJmp, 0>;
-// There is a 1-cycle data hazard if jalr depends on a immediatly preceding instrucion
+// There is a 1-cycle data hazard if jalr depends on a immediately preceding instrucion
 def : ReadAdvance<ReadJalr, -1>;
 def : ReadAdvance<ReadCSR, 0>;
 def : ReadAdvance<ReadStoreData, 0>;

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -61,10 +61,10 @@ let Latency = 2 in {
 }
 
 // mul has a latency of 1 cycle, 
-// mulh, mulhsu, mulhu take 5 cycles but RISCVSchedule.td
-// does not provide a seperate scheduler resource for those instructions
-// assuming that the majority of multiplications take 1 cycle
 def : WriteRes<WriteIMul, [cv32e40pUnitMul]>;
+// mulh, mulhsu and mulhu take 5 cycles
+def cv32e40pUnit_wr : SchedWriteRes<[cv32e40pUnitMul]> {let Latency = 5; let ResourceCycles = [5]; }
+def : InstRW<[cv32e40pUnit_wr], (instregex "MULHS?U?")>;
 
 // Division and remainder, assuming worst case latency
 def : WriteRes<WriteIDiv, [cv32e40pUnitDiv]> {

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Source for Latency and Hazard details:
+// https://cv32e40p.readthedocs.io/en/latest/pipeline.html
+//
 //===----------------------------------------------------------------------===//
 
 def cv32e40pModel : SchedMachineModel {

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -16,15 +16,12 @@ def cv32e40pModel : SchedMachineModel {
 }
 
 // ===---------------------------------------------------------------------===//
-
+// The cv32e40p is single-issue
+// so everthing can be modeled as a single resource
+// The arm Cortex M4 is modeled in a similar way
 let BufferSize = 0 in {
-def cv32e40pUnitLSU         : ProcResource<1>; // Load/Store
-def cv32e40pUnitBranch      : ProcResource<1>; // Branch/JumpDecoder
-def cv32e40pUnitALU         : ProcResource<1>; // ALU
-def cv32e40pUnitMul         : ProcResource<1>; // Multiply
-def cv32e40pUnitDiv         : ProcResource<1>; // Division
-def cv32e40pUnitFPU         : ProcResource<1>; // Optional FPU 
-def cv32e40pUnitCSR         : ProcResource<1>; // CSR
+  def cv32e40pUnit : ProcResource<1>;
+  def cv32e40pUnitFPU : ProcResource<1>; // Optional FPU 
 } 
 
 
@@ -33,52 +30,52 @@ def cv32e40pUnitCSR         : ProcResource<1>; // CSR
 let SchedModel = cv32e40pModel in {
 
 // ALU
-def : WriteRes<WriteIALU, [cv32e40pUnitALU]>;
-def : WriteRes<WriteShiftImm, [cv32e40pUnitALU]>;
-def : WriteRes<WriteShiftReg, [cv32e40pUnitALU]>;
+def : WriteRes<WriteIALU, [cv32e40pUnit]>;
+def : WriteRes<WriteShiftImm, [cv32e40pUnit]>;
+def : WriteRes<WriteShiftReg, [cv32e40pUnit]>;
 
 // Store, assuming they are word aligned
-def : WriteRes<WriteSTB, [cv32e40pUnitLSU]>; // sb
-def : WriteRes<WriteSTH, [cv32e40pUnitLSU]>; // sh
-def : WriteRes<WriteSTW, [cv32e40pUnitLSU]>; // sw
+def : WriteRes<WriteSTB, [cv32e40pUnit]>; // sb
+def : WriteRes<WriteSTH, [cv32e40pUnit]>; // sh
+def : WriteRes<WriteSTW, [cv32e40pUnit]>; // sw
 
 // Load (lh, lw, lbu, lhu), assuming they are word aligned
 // Loads/Stores are pipelined across the EX and WB stage, so ResourceCycle = 1 (is the default)
 // A data-hazard occurs when the result of a load is used in the next instruction
 // This could be modeled with a latency of 2, but a Latency = 3 provided better results in benchmarks
 let Latency = 3 in {
-  def : WriteRes<WriteLDH, [cv32e40pUnitLSU]>; // lh, lhu
-  def : WriteRes<WriteLDW, [cv32e40pUnitLSU]>; // lw
-  def : WriteRes<WriteLDWU, [cv32e40pUnitLSU]>;
-  def : WriteRes<WriteLDB, [cv32e40pUnitLSU]>; // lbu
+  def : WriteRes<WriteLDH, [cv32e40pUnit]>; // lh, lhu
+  def : WriteRes<WriteLDW, [cv32e40pUnit]>; // lw
+  def : WriteRes<WriteLDWU, [cv32e40pUnit]>;
+  def : WriteRes<WriteLDB, [cv32e40pUnit]>; // lbu
 }
 
 // Jump instructions, assuming jumps are word aligned
 let Latency = 2 in {
-  def : WriteRes<WriteJmp, [cv32e40pUnitBranch]>;
-  def : WriteRes<WriteJal, [cv32e40pUnitBranch]>;
-  def : WriteRes<WriteJalr, [cv32e40pUnitBranch]>;
-  def : WriteRes<WriteJmpReg, [cv32e40pUnitBranch]>;
+  def : WriteRes<WriteJmp, [cv32e40pUnit]>;
+  def : WriteRes<WriteJal, [cv32e40pUnit]>;
+  def : WriteRes<WriteJalr, [cv32e40pUnit]>;
+  def : WriteRes<WriteJmpReg, [cv32e40pUnit]>;
 }
 
 // mul has a latency of 1 cycle, 
-def : WriteRes<WriteIMul, [cv32e40pUnitMul]>;
+def : WriteRes<WriteIMul, [cv32e40pUnit]>;
 // mulh, mulhsu and mulhu take 5 cycles
-def cv32e40pUnit_wr : SchedWriteRes<[cv32e40pUnitMul]> {let Latency = 5; let ResourceCycles = [5]; }
+def cv32e40pUnit_wr : SchedWriteRes<[cv32e40pUnit]> {let Latency = 5; let ResourceCycles = [5]; }
 def : InstRW<[cv32e40pUnit_wr], (instregex "MULHS?U?")>;
 
 // Division and remainder, assuming worst case latency
-def : WriteRes<WriteIDiv, [cv32e40pUnitDiv]> {
+def : WriteRes<WriteIDiv, [cv32e40pUnit]> {
   let Latency = 35;
   let ResourceCycles = [35];
 }
 
 // 32 bit floating point operations
 // assuming worst case latency
-// load/store
-def : WriteRes<WriteFST32, [cv32e40pUnitLSU]>;
-def : WriteRes<WriteFLD32, [cv32e40pUnitLSU]>;
-let Latency = 11, let ResourceCycles = [11] in {
+// fp load/store, following the same reasoning as normal load/store
+def : WriteRes<WriteFLD32, [cv32e40pUnit]> {let Latency = 3; }
+def : WriteRes<WriteFST32, [cv32e40pUnit]>;
+let Latency = 11, ResourceCycles = [11] in {
   def : WriteRes<WriteFAdd32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFMul32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFMA32, [cv32e40pUnitFPU]>;
@@ -96,7 +93,7 @@ let Latency = 11, let ResourceCycles = [11] in {
   def : WriteRes<WriteFClass32, [cv32e40pUnitFPU]>;
 }
 // Single Precision Floating-Point Division and Square-Root
-let Latency = 12, let ResourceCycles = [12] in {
+let Latency = 12, ResourceCycles = [12] in {
   def : WriteRes<WriteFDiv32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFSqrt32, [cv32e40pUnitFPU]>;
 }
@@ -111,15 +108,15 @@ let Unsupported = true in {
   def : WriteRes<WriteLDD, []>;
   def : WriteRes<WriteSTD, []>;
   // Atomic memory
-  def : WriteRes<WriteAtomicW, [cv32e40pUnitLSU]>;
-  def : WriteRes<WriteAtomicD, [cv32e40pUnitLSU]>;
-  def : WriteRes<WriteAtomicLDW, [cv32e40pUnitLSU]>;
-  def : WriteRes<WriteAtomicLDD, [cv32e40pUnitLSU]>;
-  def : WriteRes<WriteAtomicSTW, [cv32e40pUnitLSU]>;
-  def : WriteRes<WriteAtomicSTD, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteAtomicW, []>;
+  def : WriteRes<WriteAtomicD, []>;
+  def : WriteRes<WriteAtomicLDW, []>;
+  def : WriteRes<WriteAtomicLDD, []>;
+  def : WriteRes<WriteAtomicSTW, []>;
+  def : WriteRes<WriteAtomicSTD, []>;
   // 64 bit FP load/store
-  def : WriteRes<WriteFST64, [cv32e40pUnitLSU]>;
-  def : WriteRes<WriteFLD64, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteFST64, []>;
+  def : WriteRes<WriteFLD64, []>;
   // 64 bit FP instructions 
   def : WriteRes<WriteFAdd64, []>;
   def : WriteRes<WriteFSGNJ64, []>;
@@ -141,7 +138,7 @@ let Unsupported = true in {
 } // Unsupported
 
 // assuming the worst case latency for CSR access
-def : WriteRes<WriteCSR, [cv32e40pUnitCSR]> {
+def : WriteRes<WriteCSR, [cv32e40pUnit]> {
   let Latency = 4;
   let ResourceCycles = [4];
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -1,4 +1,10 @@
-// ===---------------------------------------------------------------------===//
+//==- RISCVSchedcv32e40p.td - CV32E40P Scheduling Definitions --*- tablegen -*-=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 
 def cv32e40pModel : SchedMachineModel {
   let MicroOpBufferSize = 0; // cv32e40p is in-order.
@@ -15,7 +21,7 @@ def cv32e40pModel : SchedMachineModel {
                              HasStdExtZkr, HasVInstructions, HasVInstructionsI64];
 }
 
-// ===---------------------------------------------------------------------===//
+//===---------------------------------------------------------------------===//
 // The cv32e40p is single-issue
 // so everthing can be modeled as a single resource
 // The arm Cortex M4 is modeled in a similar way

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -5,6 +5,7 @@ def cv32e40pModel : SchedMachineModel {
   let IssueWidth = 1;
   let LoadLatency = 3; // see Load SchedWriteRes defs for more detail
   let MispredictPenalty = 3;
+  let PostRAScheduler = true;
   let CompleteModel = false;
   let UnsupportedFeatures = [HasStdExtA, HasAtomicLdSt,
                              HasStdExtZfinx, HasStdExtCOrZca,
@@ -16,7 +17,7 @@ def cv32e40pModel : SchedMachineModel {
 
 // ===---------------------------------------------------------------------===//
 
-let BufferSize = 0 in {     
+let BufferSize = 0 in {
 def cv32e40pUnitLSU         : ProcResource<1>; // Load/Store
 def cv32e40pUnitBranch      : ProcResource<1>; // Branch/JumpDecoder
 def cv32e40pUnitALU         : ProcResource<1>; // ALU
@@ -42,10 +43,10 @@ def : WriteRes<WriteSTH, [cv32e40pUnitLSU]>; // sh
 def : WriteRes<WriteSTW, [cv32e40pUnitLSU]>; // sw
 
 // Load (lh, lw, lbu, lhu), assuming they are word aligned
-// Loads/Stores are pipelined across the EX and WB stage so ResourceCycle = 1
+// Loads/Stores are pipelined across the EX and WB stage, so ResourceCycle = 1 (is the default)
 // A data-hazard occurs when the result of a load is used in the next instruction
 // This could be modeled with a latency of 2, but a Latency = 3 provided better results in benchmarks
-let Latency = 3, let ResourceCycles = [1] in {
+let Latency = 3 in {
   def : WriteRes<WriteLDH, [cv32e40pUnitLSU]>; // lh, lhu
   def : WriteRes<WriteLDW, [cv32e40pUnitLSU]>; // lw
   def : WriteRes<WriteLDWU, [cv32e40pUnitLSU]>;
@@ -77,7 +78,7 @@ def : WriteRes<WriteIDiv, [cv32e40pUnitDiv]> {
 // load/store
 def : WriteRes<WriteFST32, [cv32e40pUnitLSU]>;
 def : WriteRes<WriteFLD32, [cv32e40pUnitLSU]>;
-let Latency = 11 in {
+let Latency = 11, let ResourceCycles = [11] in {
   def : WriteRes<WriteFAdd32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFMul32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFMA32, [cv32e40pUnitFPU]>;
@@ -95,7 +96,7 @@ let Latency = 11 in {
   def : WriteRes<WriteFClass32, [cv32e40pUnitFPU]>;
 }
 // Single Precision Floating-Point Division and Square-Root
-let Latency = 12 in {
+let Latency = 12, let ResourceCycles = [12] in {
   def : WriteRes<WriteFDiv32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFSqrt32, [cv32e40pUnitFPU]>;
 }
@@ -142,6 +143,7 @@ let Unsupported = true in {
 // assuming the worst case latency for CSR access
 def : WriteRes<WriteCSR, [cv32e40pUnitCSR]> {
   let Latency = 4;
+  let ResourceCycles = [4];
 }
 def : WriteRes<WriteNop, []>;
 

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -1,7 +1,7 @@
 // ===---------------------------------------------------------------------===//
 
-def CV32E40PModel : SchedMachineModel {
-  let MicroOpBufferSize = 0; // CV32E40P is in-order.
+def cv32e40pModel : SchedMachineModel {
+  let MicroOpBufferSize = 0; // cv32e40p is in-order.
   let IssueWidth = 1;        
   let LoadLatency = 1;          
   let MispredictPenalty = 3;
@@ -17,81 +17,81 @@ def CV32E40PModel : SchedMachineModel {
 // ===---------------------------------------------------------------------===//
 
 let BufferSize = 0 in {     
-def CV32E40PUnitLSU         : ProcResource<1>; // Load/Store
-def CV32E40PUnitBranch      : ProcResource<1>; // Branch/JumpDecoder
-def CV32E40PUnitALU         : ProcResource<1>; // ALU
-def CV32E40PUnitMul         : ProcResource<1>; // Multiply
-def CV32E40PUnitDiv         : ProcResource<1>; // Division
-def CV32E40PUnitFPU         : ProcResource<1>; // Optional FPU 
-def CV32E40PUnitCSR         : ProcResource<1>; // CSR
+def cv32e40pUnitLSU         : ProcResource<1>; // Load/Store
+def cv32e40pUnitBranch      : ProcResource<1>; // Branch/JumpDecoder
+def cv32e40pUnitALU         : ProcResource<1>; // ALU
+def cv32e40pUnitMul         : ProcResource<1>; // Multiply
+def cv32e40pUnitDiv         : ProcResource<1>; // Division
+def cv32e40pUnitFPU         : ProcResource<1>; // Optional FPU 
+def cv32e40pUnitCSR         : ProcResource<1>; // CSR
 } 
 
 
 //===----------------------------------------------------------------------===//
 
-let SchedModel = CV32E40PModel in {
+let SchedModel = cv32e40pModel in {
 
 // ALU
-def : WriteRes<WriteIALU, [CV32E40PUnitALU]>;
-def : WriteRes<WriteShiftImm, [CV32E40PUnitALU]>;
-def : WriteRes<WriteShiftReg, [CV32E40PUnitALU]>;
+def : WriteRes<WriteIALU, [cv32e40pUnitALU]>;
+def : WriteRes<WriteShiftImm, [cv32e40pUnitALU]>;
+def : WriteRes<WriteShiftReg, [cv32e40pUnitALU]>;
 
 // Store (sb, sh, sw), assuming they are word aligned
-def : WriteRes<WriteSTB, [CV32E40PUnitLSU]>; // sb
-def : WriteRes<WriteSTH, [CV32E40PUnitLSU]>; // sh
-def : WriteRes<WriteSTW, [CV32E40PUnitLSU]>; // sw
+def : WriteRes<WriteSTB, [cv32e40pUnitLSU]>; // sb
+def : WriteRes<WriteSTH, [cv32e40pUnitLSU]>; // sh
+def : WriteRes<WriteSTW, [cv32e40pUnitLSU]>; // sw
 
 // Load (lh, lw, lbu, lhu), assuming they are word aligned
-def : WriteRes<WriteLDH, [CV32E40PUnitLSU]>; // lh, lhu
-def : WriteRes<WriteLDW, [CV32E40PUnitLSU]>; // lw
-def : WriteRes<WriteLDWU, [CV32E40PUnitLSU]>;
-def : WriteRes<WriteLDB, [CV32E40PUnitLSU]>; // lbu
+def : WriteRes<WriteLDH, [cv32e40pUnitLSU]>; // lh, lhu
+def : WriteRes<WriteLDW, [cv32e40pUnitLSU]>; // lw
+def : WriteRes<WriteLDWU, [cv32e40pUnitLSU]>;
+def : WriteRes<WriteLDB, [cv32e40pUnitLSU]>; // lbu
 
 // Jump instructions, assuming jumps are word alligned
 let Latency = 2 in {
-  def : WriteRes<WriteJmp, [CV32E40PUnitBranch]>;
-  def : WriteRes<WriteJal, [CV32E40PUnitBranch]>;
-  def : WriteRes<WriteJalr, [CV32E40PUnitBranch]>;
-  def : WriteRes<WriteJmpReg, [CV32E40PUnitBranch]>;
+  def : WriteRes<WriteJmp, [cv32e40pUnitBranch]>;
+  def : WriteRes<WriteJal, [cv32e40pUnitBranch]>;
+  def : WriteRes<WriteJalr, [cv32e40pUnitBranch]>;
+  def : WriteRes<WriteJmpReg, [cv32e40pUnitBranch]>;
 }
 
 // mul has a latency of 1 cycle, 
 // mulh, mulhsu, mulhu take 5 cycles but RISCVSchedule.td
 // does not provide a seperate scheduler resource for those instructions
 // assuming that the majority of multiplications take 1 cycle
-def : WriteRes<WriteIMul, [CV32E40PUnitMul]>;
+def : WriteRes<WriteIMul, [cv32e40pUnitMul]>;
 
 // Division and remainder, assuming worst case latency
-def : WriteRes<WriteIDiv, [CV32E40PUnitDiv]> {
+def : WriteRes<WriteIDiv, [cv32e40pUnitDiv]> {
   let Latency = 35;
   let ResourceCycles = [35];
 }
 
 // 32 bit floating point operations
 // assuming worst case latency
-def : WriteRes<WriteFST32, [CV32E40PUnitLSU]>;
-def : WriteRes<WriteFLD32, [CV32E40PUnitLSU]>;
+def : WriteRes<WriteFST32, [cv32e40pUnitLSU]>;
+def : WriteRes<WriteFLD32, [cv32e40pUnitLSU]>;
 let Latency = 11 in {
-  def : WriteRes<WriteFAdd32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFSGNJ32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFMinMax32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFAdd32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFSGNJ32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFMinMax32, [cv32e40pUnitFPU]>;
   // conversions
-  def : WriteRes<WriteFCvtI32ToF32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFCvtI64ToF32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFCvtF32ToI32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFCvtF32ToI64, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFMovF32ToI32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFMovI32ToF32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFCvtI32ToF32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFCvtI64ToF32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFCvtF32ToI32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFCvtF32ToI64, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFMovF32ToI32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFMovI32ToF32, [cv32e40pUnitFPU]>;
 
-  def : WriteRes<WriteFCmp32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFClass32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFMul32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFMA32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFCmp32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFClass32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFMul32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFMA32, [cv32e40pUnitFPU]>;
 }
 // Single Precision Floating-Point Division and Square-Root
 let Latency = 12 in {
-  def : WriteRes<WriteFDiv32, [CV32E40PUnitFPU]>;
-  def : WriteRes<WriteFSqrt32, [CV32E40PUnitFPU]>;
+  def : WriteRes<WriteFDiv32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFSqrt32, [cv32e40pUnitFPU]>;
 }
 
 
@@ -108,16 +108,16 @@ let Unsupported = true in {
   def : WriteRes<WriteSTD, []>;
 
   // Atomic memory
-  def : WriteRes<WriteAtomicW, [CV32E40PUnitLSU]>;
-  def : WriteRes<WriteAtomicD, [CV32E40PUnitLSU]>;
-  def : WriteRes<WriteAtomicLDW, [CV32E40PUnitLSU]>;
-  def : WriteRes<WriteAtomicLDD, [CV32E40PUnitLSU]>;
-  def : WriteRes<WriteAtomicSTW, [CV32E40PUnitLSU]>;
-  def : WriteRes<WriteAtomicSTD, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteAtomicW, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteAtomicD, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteAtomicLDW, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteAtomicLDD, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteAtomicSTW, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteAtomicSTD, [cv32e40pUnitLSU]>;
 
   // 64 bit FP load/store
-  def : WriteRes<WriteFST64, [CV32E40PUnitLSU]>;
-  def : WriteRes<WriteFLD64, [CV32E40PUnitLSU]>;
+  def : WriteRes<WriteFST64, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteFLD64, [cv32e40pUnitLSU]>;
 
   // 64 bit FP instructions 
   def : WriteRes<WriteFAdd64, []>;
@@ -142,14 +142,14 @@ let Unsupported = true in {
 // Others
 // assuming the worst case latency for CSR access
 // as there are no scheduler resources to differentiate them
-def : WriteRes<WriteCSR, [CV32E40PUnitCSR]> {
+def : WriteRes<WriteCSR, [cv32e40pUnitCSR]> {
   let Latency = 4;
 }
 def : WriteRes<WriteNop, []>;
 
 //===----------------------------------------------------------------------===//
 // Bypass and advance
-// CV32E40P has no forwarding 
+// cv32e40p has no forwarding 
 def : ReadAdvance<ReadJmp, 0>;
 def : ReadAdvance<ReadJalr, 0>;
 def : ReadAdvance<ReadCSR, 0>;

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -2,8 +2,8 @@
 
 def cv32e40pModel : SchedMachineModel {
   let MicroOpBufferSize = 0; // cv32e40p is in-order.
-  let IssueWidth = 1;        
-  let LoadLatency = 1;          
+  let IssueWidth = 1;
+  let LoadLatency = 3; // see Load SchedWriteRes defs for more detail
   let MispredictPenalty = 3;
   let CompleteModel = false;
   let UnsupportedFeatures = [HasStdExtA, HasAtomicLdSt,
@@ -36,16 +36,21 @@ def : WriteRes<WriteIALU, [cv32e40pUnitALU]>;
 def : WriteRes<WriteShiftImm, [cv32e40pUnitALU]>;
 def : WriteRes<WriteShiftReg, [cv32e40pUnitALU]>;
 
-// Store (sb, sh, sw), assuming they are word aligned
+// Store, assuming they are word aligned
 def : WriteRes<WriteSTB, [cv32e40pUnitLSU]>; // sb
 def : WriteRes<WriteSTH, [cv32e40pUnitLSU]>; // sh
 def : WriteRes<WriteSTW, [cv32e40pUnitLSU]>; // sw
 
 // Load (lh, lw, lbu, lhu), assuming they are word aligned
-def : WriteRes<WriteLDH, [cv32e40pUnitLSU]>; // lh, lhu
-def : WriteRes<WriteLDW, [cv32e40pUnitLSU]>; // lw
-def : WriteRes<WriteLDWU, [cv32e40pUnitLSU]>;
-def : WriteRes<WriteLDB, [cv32e40pUnitLSU]>; // lbu
+// Loads/Stores are pipelined across the EX and WB stage so ResourceCycle = 1
+// A data-hazard occurs when the result of a load is used in the next instruction
+// This could be modeled with a latency of 2, but a Latency = 3 provided better results in benchmarks
+let Latency = 3, let ResourceCycles = [1] in {
+  def : WriteRes<WriteLDH, [cv32e40pUnitLSU]>; // lh, lhu
+  def : WriteRes<WriteLDW, [cv32e40pUnitLSU]>; // lw
+  def : WriteRes<WriteLDWU, [cv32e40pUnitLSU]>;
+  def : WriteRes<WriteLDB, [cv32e40pUnitLSU]>; // lbu
+}
 
 // Jump instructions, assuming jumps are word aligned
 let Latency = 2 in {
@@ -141,10 +146,10 @@ def : WriteRes<WriteCSR, [cv32e40pUnitCSR]> {
 def : WriteRes<WriteNop, []>;
 
 //===----------------------------------------------------------------------===//
-// Bypass and advance
-// cv32e40p has no forwarding 
+// ReadAdvance definitions
 def : ReadAdvance<ReadJmp, 0>;
-def : ReadAdvance<ReadJalr, 0>;
+// There is a 1-cycle data hazard if jalr depends on a immediatly preceding instrucion
+def : ReadAdvance<ReadJalr, -1>;
 def : ReadAdvance<ReadCSR, 0>;
 def : ReadAdvance<ReadStoreData, 0>;
 def : ReadAdvance<ReadMemBase, 0>;

--- a/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedcv32e40p.td
@@ -47,7 +47,7 @@ def : WriteRes<WriteLDW, [cv32e40pUnitLSU]>; // lw
 def : WriteRes<WriteLDWU, [cv32e40pUnitLSU]>;
 def : WriteRes<WriteLDB, [cv32e40pUnitLSU]>; // lbu
 
-// Jump instructions, assuming jumps are word alligned
+// Jump instructions, assuming jumps are word aligned
 let Latency = 2 in {
   def : WriteRes<WriteJmp, [cv32e40pUnitBranch]>;
   def : WriteRes<WriteJal, [cv32e40pUnitBranch]>;
@@ -69,10 +69,13 @@ def : WriteRes<WriteIDiv, [cv32e40pUnitDiv]> {
 
 // 32 bit floating point operations
 // assuming worst case latency
+// load/store
 def : WriteRes<WriteFST32, [cv32e40pUnitLSU]>;
 def : WriteRes<WriteFLD32, [cv32e40pUnitLSU]>;
 let Latency = 11 in {
   def : WriteRes<WriteFAdd32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFMul32, [cv32e40pUnitFPU]>;
+  def : WriteRes<WriteFMA32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFSGNJ32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFMinMax32, [cv32e40pUnitFPU]>;
   // conversions
@@ -82,20 +85,15 @@ let Latency = 11 in {
   def : WriteRes<WriteFCvtF32ToI64, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFMovF32ToI32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFMovI32ToF32, [cv32e40pUnitFPU]>;
-
+  // compare and classify
   def : WriteRes<WriteFCmp32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFClass32, [cv32e40pUnitFPU]>;
-  def : WriteRes<WriteFMul32, [cv32e40pUnitFPU]>;
-  def : WriteRes<WriteFMA32, [cv32e40pUnitFPU]>;
 }
 // Single Precision Floating-Point Division and Square-Root
 let Latency = 12 in {
   def : WriteRes<WriteFDiv32, [cv32e40pUnitFPU]>;
   def : WriteRes<WriteFSqrt32, [cv32e40pUnitFPU]>;
 }
-
-
-
 
 let Unsupported = true in {
   // RV64I
@@ -106,7 +104,6 @@ let Unsupported = true in {
   def : WriteRes<WriteIMul32, []>;
   def : WriteRes<WriteLDD, []>;
   def : WriteRes<WriteSTD, []>;
-
   // Atomic memory
   def : WriteRes<WriteAtomicW, [cv32e40pUnitLSU]>;
   def : WriteRes<WriteAtomicD, [cv32e40pUnitLSU]>;
@@ -114,11 +111,9 @@ let Unsupported = true in {
   def : WriteRes<WriteAtomicLDD, [cv32e40pUnitLSU]>;
   def : WriteRes<WriteAtomicSTW, [cv32e40pUnitLSU]>;
   def : WriteRes<WriteAtomicSTD, [cv32e40pUnitLSU]>;
-
   // 64 bit FP load/store
   def : WriteRes<WriteFST64, [cv32e40pUnitLSU]>;
   def : WriteRes<WriteFLD64, [cv32e40pUnitLSU]>;
-
   // 64 bit FP instructions 
   def : WriteRes<WriteFAdd64, []>;
   def : WriteRes<WriteFSGNJ64, []>;
@@ -139,9 +134,7 @@ let Unsupported = true in {
   def : WriteRes<WriteFSqrt64, []>;
 } // Unsupported
 
-// Others
 // assuming the worst case latency for CSR access
-// as there are no scheduler resources to differentiate them
 def : WriteRes<WriteCSR, [cv32e40pUnitCSR]> {
   let Latency = 4;
 }


### PR DESCRIPTION
A simple sub-target for the cv32e40p. When benchmarking coremark, using core-v-verif, TuneNoDefaultUnroll provided slight improvements.