### PR TITLE
Update naming for xcvmem instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -494,36 +494,36 @@ let Predicates = [HasExtXcvbi], hasSideEffects = 0, mayLoad = 0, mayStore = 0, i
 let Predicates = [HasExtXcvmem], hasSideEffects = 0, mayLoad = 1, mayStore = 0, Constraints = "$rs1_wb = $rs1" in {
   // Register-Immediate load with post-increment
   def CV_LB_ri_inc  : RVInstLoad_ri_inc<0b000, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, simm12:$imm12),
-                                        "cv.lb", "$rd, ${imm12}(${rs1}!)", []>,
+                                        "cv.lb", "$rd, (${rs1}), ${imm12}", []>,
                       Sched<[]>;
   def CV_LBU_ri_inc : RVInstLoad_ri_inc<0b100, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, simm12:$imm12),
-                                        "cv.lbu", "$rd, ${imm12}(${rs1}!)", []>,
+                                        "cv.lbu", "$rd, (${rs1}), ${imm12}", []>,
                       Sched<[]>;
   def CV_LH_ri_inc  : RVInstLoad_ri_inc<0b001, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, simm12:$imm12),
-                                        "cv.lh", "$rd, ${imm12}(${rs1}!)", []>,
+                                        "cv.lh", "$rd, (${rs1}), ${imm12}", []>,
                       Sched<[]>;
   def CV_LHU_ri_inc : RVInstLoad_ri_inc<0b101, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, simm12:$imm12),
-                                        "cv.lhu", "$rd, ${imm12}(${rs1}!)", []>,
+                                        "cv.lhu", "$rd, (${rs1}), ${imm12}", []>,
                       Sched<[]>;
   def CV_LW_ri_inc  : RVInstLoad_ri_inc<0b010, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, simm12:$imm12),
-                                        "cv.lw", "$rd, ${imm12}(${rs1}!)", []>,
+                                        "cv.lw", "$rd, (${rs1}), ${imm12}", []>,
                       Sched<[]>;
 
   // Register-Register load with post-increment
   def CV_LB_rr_inc  : RVInstLoad_rr_inc<0b0000000, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, GPR:$rs2),
-                                        "cv.lb", "$rd, ${rs2}(${rs1}!)", []>,
+                                        "cv.lb", "$rd, (${rs1}), ${rs2}", []>,
                       Sched<[]>;
   def CV_LBU_rr_inc : RVInstLoad_rr_inc<0b0001000, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, GPR:$rs2),
-                                        "cv.lbu", "$rd, ${rs2}(${rs1}!)", []>,
+                                        "cv.lbu", "$rd, (${rs1}), ${rs2}", []>,
                       Sched<[]>;
   def CV_LH_rr_inc  : RVInstLoad_rr_inc<0b0000001, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, GPR:$rs2),
-                                        "cv.lh", "$rd, ${rs2}(${rs1}!)", []>,
+                                        "cv.lh", "$rd, (${rs1}), ${rs2}", []>,
                       Sched<[]>;
   def CV_LHU_rr_inc : RVInstLoad_rr_inc<0b0001001, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, GPR:$rs2),
-                                        "cv.lhu", "$rd, ${rs2}(${rs1}!)", []>,
+                                        "cv.lhu", "$rd, (${rs1}), ${rs2}", []>,
                       Sched<[]>;
   def CV_LW_rr_inc  : RVInstLoad_rr_inc<0b0000010, (outs GPR:$rd, GPR:$rs1_wb), (ins GPR:$rs1, GPR:$rs2),
-                                        "cv.lw", "$rd, ${rs2}(${rs1}!)", []>,
+                                        "cv.lw", "$rd, (${rs1}), ${rs2}", []>,
                       Sched<[]>;
 } // Predicates = [HasExtXcvmem], hasSideEffects = 0, mayLoad = 1, mayStore = 0, Constraints = "$rs1_wb = $rs1"
 
@@ -550,24 +550,24 @@ let Predicates = [HasExtXcvmem], hasSideEffects = 0, mayLoad = 1, mayStore = 0 i
 let Predicates = [HasExtXcvmem], hasSideEffects = 0, mayLoad = 0, mayStore = 1, Constraints = "$rs1_wb = $rs1" in {
   // Register-Immediate store with post-increment
   def CV_SB_ri_inc : RVInstStore_ri_inc<0b000, (outs GPR:$rs1_wb), (ins GPR:$rs2, GPR:$rs1, simm12:$imm12),
-                                        "cv.sb", "$rs2, ${imm12}(${rs1}!)", []>,
+                                        "cv.sb", "$rs2, (${rs1}), ${imm12}", []>,
                      Sched<[]>;
   def CV_SH_ri_inc : RVInstStore_ri_inc<0b001, (outs GPR:$rs1_wb), (ins GPR:$rs2, GPR:$rs1, simm12:$imm12),
-                                        "cv.sh", "$rs2, ${imm12}(${rs1}!)", []>,
+                                        "cv.sh", "$rs2, (${rs1}), ${imm12}", []>,
                      Sched<[]>;
   def CV_SW_ri_inc : RVInstStore_ri_inc<0b010, (outs GPR:$rs1_wb), (ins GPR:$rs2, GPR:$rs1, simm12:$imm12),
-                                        "cv.sw", "$rs2, ${imm12}(${rs1}!)", []>,
+                                        "cv.sw", "$rs2, (${rs1}), ${imm12}", []>,
                      Sched<[]>;
 
   // Register-Register store with post-increment
   def CV_SB_rr_inc : RVInstStore_rr_inc<0b011, 0b0010000, (outs GPR:$rs1_wb), (ins GPR:$rs2, GPR:$rs1, GPR:$rs3),
-                                        "cv.sb", "$rs2, ${rs3}(${rs1}!)", []>,
+                                        "cv.sb", "$rs2, (${rs1}), ${rs3}", []>,
                      Sched<[]>;
   def CV_SH_rr_inc : RVInstStore_rr_inc<0b011, 0b0010001, (outs GPR:$rs1_wb), (ins GPR:$rs2, GPR:$rs1, GPR:$rs3),
-                                        "cv.sh", "$rs2, ${rs3}(${rs1}!)", []>,
+                                        "cv.sh", "$rs2, (${rs1}), ${rs3}", []>,
                      Sched<[]>;
   def CV_SW_rr_inc : RVInstStore_rr_inc<0b011, 0b0010010, (outs GPR:$rs1_wb), (ins GPR:$rs2, GPR:$rs1, GPR:$rs3),
-                                        "cv.sw", "$rs2, ${rs3}(${rs1}!)", []>,
+                                        "cv.sw", "$rs2, (${rs1}), ${rs3}", []>,
                      Sched<[]>;
 } // Predicates = [HasExtXcvmem], hasSideEffects = 0, mayLoad = 0, mayStore = 1, Constraints = "$rs1_wb = $rs1"
 

--- a/llvm/test/CodeGen/RISCV/corev/mem.ll
+++ b/llvm/test/CodeGen/RISCV/corev/mem.ll
@@ -5,7 +5,7 @@
 define <2 x i32> @lb_ri_inc(i8* %a) {
 ; CHECK-LABEL: lb_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.lb a1, 42(a0!)
+; CHECK-NEXT:    cv.lb a1, (a0), 42
 ; CHECK-NEXT:    ret
   %1 = load i8, i8* %a
   %2 = sext i8 %1 to i32
@@ -19,7 +19,7 @@ define <2 x i32> @lb_ri_inc(i8* %a) {
 define <2 x i32> @lb_rr_inc(i8* %a, i32 %b) {
 ; CHECK-LABEL: lb_rr_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.lb a1, a1(a0!)
+; CHECK-NEXT:    cv.lb a1, (a0), a1
 ; CHECK-NEXT:    ret
   %1 = load i8, i8* %a
   %2 = sext i8 %1 to i32
@@ -44,7 +44,7 @@ define i32 @lb_rr(i8* %a, i32 %b) {
 define <2 x i32> @lbu_ri_inc(i8* %a) {
 ; CHECK-LABEL: lbu_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.lbu a1, 42(a0!)
+; CHECK-NEXT:    cv.lbu a1, (a0), 42
 ; CHECK-NEXT:    ret
   %1 = load i8, i8* %a
   %2 = zext i8 %1 to i32
@@ -58,7 +58,7 @@ define <2 x i32> @lbu_ri_inc(i8* %a) {
 define <2 x i32> @lbu_rr_inc(i8* %a, i32 %b) {
 ; CHECK-LABEL: lbu_rr_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.lbu a1, a1(a0!)
+; CHECK-NEXT:    cv.lbu a1, (a0), a1
 ; CHECK-NEXT:    ret
   %1 = load i8, i8* %a
   %2 = zext i8 %1 to i32
@@ -83,7 +83,7 @@ define i32 @lbu_rr(i8* %a, i32 %b) {
 define <2 x i32> @lh_ri_inc(i16* %a) {
 ; CHECK-LABEL: lh_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.lh a1, 84(a0!)
+; CHECK-NEXT:    cv.lh a1, (a0), 84
 ; CHECK-NEXT:    ret
   %1 = load i16, i16* %a
   %2 = sext i16 %1 to i32
@@ -98,7 +98,7 @@ define <2 x i32> @lh_rr_inc(i16* %a, i32 %b) {
 ; CHECK-LABEL: lh_rr_inc:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    cv.lh a1, a1(a0!)
+; CHECK-NEXT:    cv.lh a1, (a0), a1
 ; CHECK-NEXT:    ret
   %1 = load i16, i16* %a
   %2 = sext i16 %1 to i32
@@ -124,7 +124,7 @@ define i32 @lh_rr(i16* %a, i32 %b) {
 define <2 x i32> @lhu_ri_inc(i16* %a) {
 ; CHECK-LABEL: lhu_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.lhu a1, 84(a0!)
+; CHECK-NEXT:    cv.lhu a1, (a0), 84
 ; CHECK-NEXT:    ret
   %1 = load i16, i16* %a
   %2 = zext i16 %1 to i32
@@ -139,7 +139,7 @@ define <2 x i32> @lhu_rr_inc(i16* %a, i32 %b) {
 ; CHECK-LABEL: lhu_rr_inc:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    cv.lhu a1, a1(a0!)
+; CHECK-NEXT:    cv.lhu a1, (a0), a1
 ; CHECK-NEXT:    ret
   %1 = load i16, i16* %a
   %2 = zext i16 %1 to i32
@@ -165,7 +165,7 @@ define i32 @lhu_rr(i16* %a, i32 %b) {
 define <2 x i32> @lw_ri_inc(i32* %a) {
 ; CHECK-LABEL: lw_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.lw a1, 168(a0!)
+; CHECK-NEXT:    cv.lw a1, (a0), 168
 ; CHECK-NEXT:    ret
   %1 = load i32, i32* %a
   %2 = getelementptr i32, i32* %a, i32 42
@@ -179,7 +179,7 @@ define <2 x i32> @lw_rr_inc(i32* %a, i32 %b) {
 ; CHECK-LABEL: lw_rr_inc:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    slli a1, a1, 2
-; CHECK-NEXT:    cv.lw a1, a1(a0!)
+; CHECK-NEXT:    cv.lw a1, (a0), a1
 ; CHECK-NEXT:    ret
   %1 = load i32, i32* %a
   %2 = getelementptr i32, i32* %a, i32 %b
@@ -203,7 +203,7 @@ define i32 @lw_rr(i32* %a, i32 %b) {
 define i8* @sb_ri_inc(i8* %a, i8 %b) {
 ; CHECK-LABEL: sb_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.sb a1, 42(a0!)
+; CHECK-NEXT:    cv.sb a1, (a0), 42
 ; CHECK-NEXT:    ret
   store i8 %b, i8* %a
   %1 = getelementptr i8, i8* %a, i32 42
@@ -213,7 +213,7 @@ define i8* @sb_ri_inc(i8* %a, i8 %b) {
 define i8* @sb_rr_inc(i8* %a, i8 %b, i32 %c) {
 ; CHECK-LABEL: sb_rr_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.sb a1, a2(a0!)
+; CHECK-NEXT:    cv.sb a1, (a0), a2
 ; CHECK-NEXT:    ret
   store i8 %b, i8* %a
   %1 = getelementptr i8, i8* %a, i32 %c
@@ -233,7 +233,7 @@ define void @sb_rr(i8* %a, i8 %b, i32 %c) {
 define i16* @sh_ri_inc(i16* %a, i16 %b) {
 ; CHECK-LABEL: sh_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.sh a1, 84(a0!)
+; CHECK-NEXT:    cv.sh a1, (a0), 84
 ; CHECK-NEXT:    ret
   store i16 %b, i16* %a
   %1 = getelementptr i16, i16* %a, i32 42
@@ -244,7 +244,7 @@ define i16* @sh_rr_inc(i16* %a, i16 %b, i32 %c) {
 ; CHECK-LABEL: sh_rr_inc:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    slli a2, a2, 1
-; CHECK-NEXT:    cv.sh a1, a2(a0!)
+; CHECK-NEXT:    cv.sh a1, (a0), a2
 ; CHECK-NEXT:    ret
   store i16 %b, i16* %a
   %1 = getelementptr i16, i16* %a, i32 %c
@@ -265,7 +265,7 @@ define void @sh_rr(i16* %a, i16 %b, i32 %c) {
 define i32* @sw_ri_inc(i32* %a, i32 %b) {
 ; CHECK-LABEL: sw_ri_inc:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.sw a1, 168(a0!)
+; CHECK-NEXT:    cv.sw a1, (a0), 168
 ; CHECK-NEXT:    ret
   store i32 %b, i32* %a
   %1 = getelementptr i32, i32* %a, i32 42
@@ -276,7 +276,7 @@ define i32* @sw_rr_inc(i32* %a, i32 %b, i32 %c) {
 ; CHECK-LABEL: sw_rr_inc:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    slli a2, a2, 2
-; CHECK-NEXT:    cv.sw a1, a2(a0!)
+; CHECK-NEXT:    cv.sw a1, (a0), a2
 ; CHECK-NEXT:    ret
   store i32 %b, i32* %a
   %1 = getelementptr i32, i32* %a, i32 %c

--- a/llvm/test/MC/RISCV/corev/mem/lb-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/lb-invalid.s
@@ -1,29 +1,32 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.lb t0, 0(0!)
-# CHECK-ERROR: expected register
-
-cv.lb 0, 0(t1!)
+cv.lb t0, (0), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lb t0, 0(t1)
+cv.lb 0, (t1), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lb t0, 2048(t1!)
+cv.lb 0, (0), t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.lb t0, (t1), -2049
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lb t0, t1(0!)
-# CHECK-ERROR: expected register
+cv.lb t0, (t1), 2048
+# CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lb 0, t1(t1!)
+cv.lb t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lb t0, t1(0)
-# CHECK-ERROR: expected register
-
-cv.lb 0, 0(t1)
+cv.lb 0, (t1), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lb t0
 # CHECK-ERROR: too few operands for instruction
+
+cv.lb t0, (t2)
+# CHECK-ERROR: too few operands for instruction
+
+cv.lb t0, (t1), t2, t3
+# CHECK-ERROR: invalid operand for instruction

--- a/llvm/test/MC/RISCV/corev/mem/lb.s
+++ b/llvm/test/MC/RISCV/corev/mem/lb.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.lb t0, 0(t1!)
-# CHECK-INSTR: cv.lb t0, 0(t1!)
+cv.lb t0, (t1), 0
+# CHECK-INSTR: cv.lb t0, (t1), 0
 # CHECK-ENCODING: [0x8b,0x02,0x03,0x00]
 
-cv.lb a0, 2047(a1!)
-# CHECK-INSTR: cv.lb a0, 2047(a1!)
+cv.lb a0, (a1), 2047
+# CHECK-INSTR: cv.lb a0, (a1), 2047
 # CHECK-ENCODING: [0x0b,0x85,0xf5,0x7f]
 
 
 
-cv.lb t0, t2(t1!)
-# CHECK-INSTR: cv.lb t0, t2(t1!)
+cv.lb t0, (t1), t2
+# CHECK-INSTR: cv.lb t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x32,0x73,0x00]
 
-cv.lb a0, a2(a1!)
-# CHECK-INSTR: cv.lb a0, a2(a1!)
+cv.lb a0, (a1), a2
+# CHECK-INSTR: cv.lb a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x00]
 
 

--- a/llvm/test/MC/RISCV/corev/mem/lbu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/lbu-invalid.s
@@ -1,29 +1,32 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.lbu t0, 0(0!)
-# CHECK-ERROR: expected register
-
-cv.lbu 0, 0(t1!)
+cv.lbu t0, (0), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lbu t0, 0(t1)
+cv.lbu 0, (t1), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lbu t0, 2048(t1!)
+cv.lbu 0, (0), t0 
+# CHECK-ERROR: invalid operand for instruction
+
+cv.lbu t0, (t1), -2049
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lbu t0, t1(0!)
-# CHECK-ERROR: expected register
+cv.lbu t0, (t1), 2048
+# CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lbu 0, t1(t1!)
+cv.lbu t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lbu t0, t1(0)
-# CHECK-ERROR: expected register
-
-cv.lbu 0, 0(t1)
+cv.lbu 0, (t1), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lbu t0
 # CHECK-ERROR: too few operands for instruction
+
+cv.lbu t0, (t2)
+# CHECK-ERROR: too few operands for instruction
+
+cv.lbu t0, (t1), t2, t3 
+# CHECK-ERROR: invalid operand for instruction

--- a/llvm/test/MC/RISCV/corev/mem/lbu.s
+++ b/llvm/test/MC/RISCV/corev/mem/lbu.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.lbu t0, 0(t1!)
-# CHECK-INSTR: cv.lbu t0, 0(t1!)
+cv.lbu t0, (t1), 0
+# CHECK-INSTR: cv.lbu t0, (t1), 0
 # CHECK-ENCODING: [0x8b,0x42,0x03,0x00]
 
-cv.lbu a0, 2047(a1!)
-# CHECK-INSTR: cv.lbu a0, 2047(a1!)
+cv.lbu a0, (a1), 2047
+# CHECK-INSTR: cv.lbu a0, (a1), 2047
 # CHECK-ENCODING: [0x0b,0xc5,0xf5,0x7f]
 
 
 
-cv.lbu t0, t2(t1!)
-# CHECK-INSTR: cv.lbu t0, t2(t1!)
+cv.lbu t0, (t1), t2
+# CHECK-INSTR: cv.lbu t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x32,0x73,0x10]
 
-cv.lbu a0, a2(a1!)
-# CHECK-INSTR: cv.lbu a0, a2(a1!)
+cv.lbu a0, (a1), a2
+# CHECK-INSTR: cv.lbu a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x10]
 
 

--- a/llvm/test/MC/RISCV/corev/mem/lh-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/lh-invalid.s
@@ -1,29 +1,35 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.lh t0, 0(0!)
-# CHECK-ERROR: expected register
-
-cv.lh 0, 0(t1!)
+cv.lh t0, (0), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lh t0, 0(t1)
+cv.lh 0, (t1), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lh t0, 2048(t1!)
+cv.lh 0, (0), t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.lh t0, (t1), -2049
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lh t0, t1(0!)
-# CHECK-ERROR: expected register
+cv.lh t0, (t1), 2048
+# CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lh 0, t1(t1!)
+cv.lh t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lh t0, t1(0)
 # CHECK-ERROR: expected register
 
-cv.lh 0, 0(t1)
+cv.lh 0, (t1), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lh t0
 # CHECK-ERROR: too few operands for instruction
+
+cv.lh t0, (t1)
+# CHECK-ERROR: too few operands for instruction
+
+cv.lh t0, (t1), t2, t3
+# CHECK-ERROR: invalid operand for instruction

--- a/llvm/test/MC/RISCV/corev/mem/lh.s
+++ b/llvm/test/MC/RISCV/corev/mem/lh.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.lh t0, 0(t1!)
-# CHECK-INSTR: cv.lh t0, 0(t1!)
+cv.lh t0, (t1), 0
+# CHECK-INSTR: cv.lh t0, (t1), 0
 # CHECK-ENCODING: [0x8b,0x12,0x03,0x00]
 
-cv.lh a0, 2047(a1!)
-# CHECK-INSTR: cv.lh a0, 2047(a1!)
+cv.lh a0, (a1), 2047
+# CHECK-INSTR: cv.lh a0, (a1), 2047
 # CHECK-ENCODING: [0x0b,0x95,0xf5,0x7f]
 
 
 
-cv.lh t0, t2(t1!)
-# CHECK-INSTR: cv.lh t0, t2(t1!)
+cv.lh t0, (t1), t2
+# CHECK-INSTR: cv.lh t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x32,0x73,0x02]
 
-cv.lh a0, a2(a1!)
-# CHECK-INSTR: cv.lh a0, a2(a1!)
+cv.lh a0, (a1), a2
+# CHECK-INSTR: cv.lh a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x02]
 
 

--- a/llvm/test/MC/RISCV/corev/mem/lhu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/lhu-invalid.s
@@ -1,29 +1,35 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.lhu t0, 0(0!)
-# CHECK-ERROR: expected register
-
-cv.lhu 0, 0(t1!)
+cv.lhu t0, (0), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lhu t0, 0(t1)
+cv.lhu 0, (t1), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lhu t0, 2048(t1!)
+cv.lhu 0, 0(t1)
+# CHECK-ERROR: invalid operand for instruction
+
+cv.lhu t0, (t1), -2049
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lhu t0, t1(0!)
-# CHECK-ERROR: expected register
+cv.lhu t0, (t1), 2048
+# CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lhu 0, t1(t1!)
+cv.lhu t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lhu t0, t1(0)
 # CHECK-ERROR: expected register
 
-cv.lhu 0, 0(t1)
+cv.lhu 0, t0, t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lhu t0
 # CHECK-ERROR: too few operands for instruction
+
+cv.lhu t0, (t1)
+# CHECK-ERROR: too few operands for instruction
+
+cv.lhu t0, (t1), t2, t3
+# CHECK-ERROR: invalid operand for instruction

--- a/llvm/test/MC/RISCV/corev/mem/lhu.s
+++ b/llvm/test/MC/RISCV/corev/mem/lhu.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.lhu t0, 0(t1!)
-# CHECK-INSTR: cv.lhu t0, 0(t1!)
+cv.lhu t0, (t1), 0
+# CHECK-INSTR: cv.lhu t0, (t1), 0
 # CHECK-ENCODING: [0x8b,0x52,0x03,0x00]
 
-cv.lhu a0, 2047(a1!)
-# CHECK-INSTR: cv.lhu a0, 2047(a1!)
+cv.lhu a0, (a1), 2047
+# CHECK-INSTR: cv.lhu a0, (a1), 2047
 # CHECK-ENCODING: [0x0b,0xd5,0xf5,0x7f]
 
 
 
-cv.lhu t0, t2(t1!)
-# CHECK-INSTR: cv.lhu t0, t2(t1!)
+cv.lhu t0, (t1), t2
+# CHECK-INSTR: cv.lhu t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x32,0x73,0x12]
 
-cv.lhu a0, a2(a1!)
-# CHECK-INSTR: cv.lhu a0, a2(a1!)
+cv.lhu a0, (a1), a2
+# CHECK-INSTR: cv.lhu a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x12]
 
 

--- a/llvm/test/MC/RISCV/corev/mem/lw-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/lw-invalid.s
@@ -1,29 +1,35 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.lw t0, 0(0!)
-# CHECK-ERROR: expected register
-
-cv.lw 0, 0(t1!)
+cv.lw t0, (0), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lw t0, 0(t1)
+cv.lw 0, (t1), 0
 # CHECK-ERROR: invalid operand for instruction
 
-cv.lw t0, 2048(t1!)
+cv.lw 0, (0), t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.lw t0, (t1), -2049
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lw t0, t1(0!)
-# CHECK-ERROR: expected register
+cv.lw t0, (t1), 2048
+# CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.lw 0, t1(t1!)
+cv.lw t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lw t0, t1(0)
 # CHECK-ERROR: expected register
 
-cv.lw 0, 0(t1)
+cv.lw 0, (t0), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.lw t0
 # CHECK-ERROR: too few operands for instruction
+
+cv.lw t0, (t1)
+# CHECK-ERROR: too few operands for instruction
+
+cv.lw t0, (t1), t2, t3
+# CHECK-ERROR: invalid operand for instruction 

--- a/llvm/test/MC/RISCV/corev/mem/lw.s
+++ b/llvm/test/MC/RISCV/corev/mem/lw.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.lw t0, 0(t1!)
-# CHECK-INSTR: cv.lw t0, 0(t1!)
+cv.lw t0, (t1), 0
+# CHECK-INSTR: cv.lw t0, (t1), 0
 # CHECK-ENCODING: [0x8b,0x22,0x03,0x00]
 
-cv.lw a0, 2047(a1!)
-# CHECK-INSTR: cv.lw a0, 2047(a1!)
+cv.lw a0, (a1), 2047
+# CHECK-INSTR: cv.lw a0, (a1), 2047
 # CHECK-ENCODING: [0x0b,0xa5,0xf5,0x7f]
 
 
 
-cv.lw t0, t2(t1!)
-# CHECK-INSTR: cv.lw t0, t2(t1!)
+cv.lw t0, (t1), t2
+# CHECK-INSTR: cv.lw t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x32,0x73,0x04]
 
-cv.lw a0, a2(a1!)
-# CHECK-INSTR: cv.lw a0, a2(a1!)
+cv.lw a0, (a1), a2
+# CHECK-INSTR: cv.lw a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x04]
 
 

--- a/llvm/test/MC/RISCV/corev/mem/sb-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/sb-invalid.s
@@ -1,28 +1,22 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.sb t0, 0(0!)
-# CHECK-ERROR: expected register
+cv.sb t0, (0), 0
+# CHECK-ERROR: invalid operand for instruction
 
-cv.sb 0, 0(t1!)
+cv.sb 0, (t0), 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sb t0, 0(t1)
 # CHECK-ERROR: invalid operand for instruction
 
-cv.sb t0, 2048(t1!)
+cv.sb t0, (t1), 2048
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.sb t0, t1(0!)
-# CHECK-ERROR: expected register
-
-cv.sb 0, t1(t1!)
+cv.sb t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
-cv.sb t0, t1(0)
-# CHECK-ERROR: expected register
-
-cv.sb 0, 0(t1)
+cv.sb 0, (t1), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sb t0

--- a/llvm/test/MC/RISCV/corev/mem/sb.s
+++ b/llvm/test/MC/RISCV/corev/mem/sb.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.sb t0, 0(t1!)
-# CHECK-INSTR: cv.sb t0, 0(t1!)
+cv.sb t0, (t1), 0
+# CHECK-INSTR: cv.sb t0, (t1), 0
 # CHECK-ENCODING: [0x2b,0x00,0x53,0x00]
 
-cv.sb a0, 2047(a1!)
-# CHECK-INSTR: cv.sb a0, 2047(a1!)
+cv.sb a0, (a1), 2047
+# CHECK-INSTR: cv.sb a0, (a1), 2047
 # CHECK-ENCODING: [0xab,0x8f,0xa5,0x7e]
 
 
 
-cv.sb t0, t2(t1!)
-# CHECK-INSTR: cv.sb t0, t2(t1!)
+cv.sb t0, (t1), t2
+# CHECK-INSTR: cv.sb t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x33,0x53,0x20]
 
-cv.sb a0, a2(a1!)
-# CHECK-INSTR: cv.sb a0, a2(a1!)
+cv.sb a0, (a1), a2
+# CHECK-INSTR: cv.sb a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb6,0xa5,0x20]
 
 

--- a/llvm/test/MC/RISCV/corev/mem/sh-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/sh-invalid.s
@@ -1,28 +1,22 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.sh t0, 0(0!)
-# CHECK-ERROR: expected register
+cv.sh t0, (0), 0
+# CHECK-ERROR: invalid operand for instruction
 
-cv.sh 0, 0(t1!)
+cv.sh 0, (t1), 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sh t0, 0(t1)
 # CHECK-ERROR: invalid operand for instruction
 
-cv.sh t0, 2048(t1!)
+cv.sh t0, (t1), 2048
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.sh t0, t1(0!)
-# CHECK-ERROR: expected register
-
-cv.sh 0, t1(t1!)
+cv.sh t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
-cv.sh t0, t1(0)
-# CHECK-ERROR: expected register
-
-cv.sh 0, 0(t1)
+cv.sh 0, (t1), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sh t0

--- a/llvm/test/MC/RISCV/corev/mem/sh.s
+++ b/llvm/test/MC/RISCV/corev/mem/sh.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.sh t0, 0(t1!)
-# CHECK-INSTR: cv.sh t0, 0(t1!)
+cv.sh t0, (t1), 0
+# CHECK-INSTR: cv.sh t0, (t1), 0
 # CHECK-ENCODING: [0x2b,0x10,0x53,0x00]
 
-cv.sh a0, 2047(a1!)
-# CHECK-INSTR: cv.sh a0, 2047(a1!)
+cv.sh a0, (a1), 2047
+# CHECK-INSTR: cv.sh a0, (a1), 2047
 # CHECK-ENCODING: [0xab,0x9f,0xa5,0x7e]
 
 
 
-cv.sh t0, t2(t1!)
-# CHECK-INSTR: cv.sh t0, t2(t1!)
+cv.sh t0, (t1), t2
+# CHECK-INSTR: cv.sh t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x33,0x53,0x22]
 
-cv.sh a0, a2(a1!)
-# CHECK-INSTR: cv.sh a0, a2(a1!)
+cv.sh a0, (a1), a2
+# CHECK-INSTR: cv.sh a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb6,0xa5,0x22]
 
 

--- a/llvm/test/MC/RISCV/corev/mem/sw-invalid.s
+++ b/llvm/test/MC/RISCV/corev/mem/sw-invalid.s
@@ -1,28 +1,22 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+xcvmem %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
-cv.sw t0, 0(0!)
-# CHECK-ERROR: expected register
+cv.sw t0, (0), 0
+# CHECK-ERROR: invalid operand for instruction
 
-cv.sw 0, 0(t1!)
+cv.sw 0, (t1), 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sw t0, 0(t1)
 # CHECK-ERROR: invalid operand for instruction
 
-cv.sw t0, 2048(t1!)
+cv.sw t0, (t1), 2048
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
 
-cv.sw t0, t1(0!)
-# CHECK-ERROR: expected register
-
-cv.sw 0, t1(t1!)
+cv.sw t0, (0), t1
 # CHECK-ERROR: invalid operand for instruction
 
-cv.sw t0, t1(0)
-# CHECK-ERROR: expected register
-
-cv.sw 0, 0(t1)
+cv.sw 0, (t1), t1
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sw t0

--- a/llvm/test/MC/RISCV/corev/mem/sw.s
+++ b/llvm/test/MC/RISCV/corev/mem/sw.s
@@ -1,22 +1,22 @@
 # RUN: llvm-mc -triple=riscv32 --mattr=+xcvmem -show-encoding %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
 
-cv.sw t0, 0(t1!)
-# CHECK-INSTR: cv.sw t0, 0(t1!)
+cv.sw t0, (t1), 0
+# CHECK-INSTR: cv.sw t0, (t1), 0
 # CHECK-ENCODING: [0x2b,0x20,0x53,0x00]
 
-cv.sw a0, 2047(a1!)
-# CHECK-INSTR: cv.sw a0, 2047(a1!)
+cv.sw a0, (a1), 2047
+# CHECK-INSTR: cv.sw a0, (a1), 2047
 # CHECK-ENCODING: [0xab,0xaf,0xa5,0x7e]
 
 
 
-cv.sw t0, t2(t1!)
-# CHECK-INSTR: cv.sw t0, t2(t1!)
+cv.sw t0, (t1), t2
+# CHECK-INSTR: cv.sw t0, (t1), t2
 # CHECK-ENCODING: [0xab,0x33,0x53,0x24]
 
-cv.sw a0, a2(a1!)
-# CHECK-INSTR: cv.sw a0, a2(a1!)
+cv.sw a0, (a1), a2
+# CHECK-INSTR: cv.sw a0, (a1), a2
 # CHECK-ENCODING: [0x2b,0xb6,0xa5,0x24]
 
 


### PR DESCRIPTION
fix issue71 https://github.com/openhwgroup/corev-llvm-project/issues/71

spec: https://github.com/openhwgroup/cv32e40p/pull/844/files
cv.l* rD, Imm(rs1!) by cv.l* rD, (rs1), imm and resp. cv.s* rs2, Imm(rs1!) by cv.s* rs2, (rs1), imm
cv.l* rD, rs2(rs1!) by cv.l* rD, (rs1), rs2 and resp. cv.s* rs2, rs3(rs1!) by cv.s* rs2, (rs1), rs3
