### PR TITLE
C API header xcvelw

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -95,6 +95,7 @@ set(ppc_htm_files
 set(riscv_files
   riscv_corev_alu.h
   riscv_corev_bitmanip.h
+  riscv_corev_elw.h
   )
 
 set(systemz_files

--- a/clang/lib/Headers/riscv_corev_elw.h
+++ b/clang/lib/Headers/riscv_corev_elw.h
@@ -1,0 +1,33 @@
+/*===---- riscv_corev_elw.h - CORE-V event load intrinsics -----------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __RISCV_COREV_ELW_H
+#define __RISCV_COREV_ELW_H
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(__riscv_xcvelw)
+
+#define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, __nodebug__))
+
+static __inline__ unsigned long __DEFAULT_FN_ATTRS __riscv_cv_elw_elw(void *loc) {
+  return __builtin_riscv_cv_elw_elw(loc);
+}
+
+#endif // defined(__riscv_xcvelw)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // define __RISCV_COREV_ELW_H

--- a/clang/test/CodeGen/RISCV/corev-intrinsics/elw-c-api.c
+++ b/clang/test/CodeGen/RISCV/corev-intrinsics/elw-c-api.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -triple riscv32 -target-feature +xcvelw -emit-llvm %s -o - \
+// RUN:     | FileCheck %s
+
+#include <stdint.h>
+#include <riscv_corev_elw.h>
+
+// CHECK-LABEL: @test_elw
+// CHECK: @llvm.riscv.cv.elw.elw
+uint32_t test_elw(void *a) {
+	return __riscv_cv_elw_elw(a);
+}


### PR DESCRIPTION
This patch adds the C API header file for the xcvelw Clang builtins.
It also adds the CodeGen test that checks that the wrapper functions defined in the header turn into the right LLVM instrinsic when called.
Finally the patch adds the cmake support for the header file. This needs to follow the analogous patch for the xcvbitmanip builtins as that one includes the basic cmake support to add all the headers.