### PR TITLE
C API header xcvmac

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -96,6 +96,7 @@ set(riscv_files
   riscv_corev_alu.h
   riscv_corev_bitmanip.h
   riscv_corev_elw.h
+  riscv_corev_mac.h
   )
 
 set(systemz_files

--- a/clang/lib/Headers/riscv_corev_mac.h
+++ b/clang/lib/Headers/riscv_corev_mac.h
@@ -1,0 +1,109 @@
+/*===---- riscv_corev_mac.h - CORE-V multiply accumulate intrinsics --------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __RISCV_COREV_MAC_H
+#define __RISCV_COREV_MAC_H
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(__riscv_xcvmac)
+
+#define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, __nodebug__))
+
+static __inline__ long __DEFAULT_FN_ATTRS __riscv_cv_mac_mac(long a, long b, long c) {
+  return __builtin_riscv_cv_mac_mac(a, b, c);
+}
+
+static __inline__ long __DEFAULT_FN_ATTRS __riscv_cv_mac_msu(long a, long b, long c) {
+  return __builtin_riscv_cv_mac_msu(a, b, c);
+}
+
+#define __riscv_cv_mac_muluN(rs1, rs2, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_muluN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_mulhhuN(rs1, rs2, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_mulhhuN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_mulsN(rs1, rs2, SHIFT) \
+  (long) __builtin_riscv_cv_mac_mulsN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_mulhhsN(rs1, rs2, SHIFT) \
+  (long) __builtin_riscv_cv_mac_mulhhsN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_muluRN(rs1, rs2, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_muluRN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_mulhhuRN(rs1, rs2, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_mulhhuRN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_mulsRN(rs1, rs2, SHIFT) \
+  (long) __builtin_riscv_cv_mac_mulsRN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_mulhhsRN(rs1, rs2, SHIFT) \
+  (long) __builtin_riscv_cv_mac_mulhhsRN((unsigned long) (rs1), \
+                                 (unsigned long) (rs2), (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_macuN(rs1, rs2, rD, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_macuN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_machhuN(rs1, rs2, rD, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_machhuN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_macsN(rs1, rs2, rD, SHIFT) \
+  (long) __builtin_riscv_cv_mac_macsN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_machhsN(rs1, rs2, rD, SHIFT) \
+  (long) __builtin_riscv_cv_mac_machhsN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_macuRN(rs1, rs2, rD, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_macuRN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_machhuRN(rs1, rs2, rD, SHIFT) \
+  (unsigned long) __builtin_riscv_cv_mac_machhuRN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_macsRN(rs1, rs2, rD, SHIFT) \
+  (long) __builtin_riscv_cv_mac_macsRN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#define __riscv_cv_mac_machhsRN(rs1, rs2, rD, SHIFT) \
+  (long) __builtin_riscv_cv_mac_machhsRN((unsigned long) (rs1), \
+                                  (unsigned long) (rs2), (unsigned long) (rD), \
+                                  (const uint8_t) (SHIFT))
+
+#endif // defined(__riscv_xcvmac)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // define __RISCV_COREV_MAC_H

--- a/clang/test/CodeGen/RISCV/corev-intrinsics/mac-c-api.c
+++ b/clang/test/CodeGen/RISCV/corev-intrinsics/mac-c-api.c
@@ -1,0 +1,114 @@
+// RUN: %clang_cc1 -triple riscv32 -target-feature +xcvmac -emit-llvm %s -o - \
+// RUN:     | FileCheck %s
+
+#include <stdint.h>
+#include <riscv_corev_mac.h>
+
+// CHECK-LABEL: @test_mac_mac
+// CHECK: @llvm.riscv.cv.mac.mac
+int32_t test_mac_mac(int32_t x, int32_t y, int32_t z) {
+    return __riscv_cv_mac_mac(x, y, z);
+}
+
+// CHECK-LABEL: @test_mac_msu
+// CHECK: @llvm.riscv.cv.mac.msu
+int32_t test_mac_msu(int32_t x, int32_t y, int32_t z) {
+    return __riscv_cv_mac_msu(x, y, z);
+}
+
+// CHECK-LABEL: @test_mac_muluN
+// CHECK: @llvm.riscv.cv.mac.muluN
+uint32_t test_mac_muluN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_muluN(x, y, 0);
+}
+
+// CHECK-LABEL: @test_mac_mulhhuN
+// CHECK: @llvm.riscv.cv.mac.mulhhuN
+uint32_t test_mac_mulhhuN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_mulhhuN(x, y, 0);
+}
+
+// CHECK-LABEL: @test_mac_mulsN
+// CHECK:  @llvm.riscv.cv.mac.mulsN
+int32_t test_mac_mulsN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_mulsN(x, y, 0);
+}
+
+// CHECK-LABEL: @test_mac_mulhhsN
+// CHECK: @llvm.riscv.cv.mac.mulhhsN
+int32_t test_mac_mulhhsN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_mulhhsN(x, y, 0);
+}
+
+// CHECK-LABEL: @test_mac_muluRN
+// CHECK: @llvm.riscv.cv.mac.muluRN
+uint32_t test_mac_muluRN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_muluRN(x, y, 0);
+}
+
+// CHECK-LABEL: @test_mac_mulhhuRN
+// CHECK: @llvm.riscv.cv.mac.mulhhuRN
+uint32_t test_mac_mulhhuRN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_mulhhuRN(x, y, 0);
+}
+
+// CHECK-LABEL: @test_mac_mulsRN
+// CHECK: @llvm.riscv.cv.mac.mulsRN
+int32_t test_mac_mulsRN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_mulsRN(x, y, 0);
+}
+
+// CHECK-LABEL: @test_mac_mulhhsRN
+// CHECK: @llvm.riscv.cv.mac.mulhhsRN
+int32_t test_mac_mulhhsRN(uint32_t x, uint32_t y) {
+    return __riscv_cv_mac_mulhhsRN(x, y, 0);
+}
+
+// 16-bit x 16-bit multiply-accumulate
+// CHECK-LABEL: @test_mac_macuN
+// CHECK: @llvm.riscv.cv.mac.macuN
+uint32_t test_mac_macuN(uint32_t x, uint32_t y, uint32_t z) {
+    return __riscv_cv_mac_macuN(x, y, z, 0);
+}
+
+// CHECK-LABEL: @test_mac_machhuN
+// CHECK: @llvm.riscv.cv.mac.machhuN
+uint32_t test_mac_machhuN(uint32_t x, uint32_t y, uint32_t z) {
+    return __riscv_cv_mac_machhuN(x, y, z, 0);
+}
+
+// CHECK-LABEL: @test_mac_macsN
+// CHECK: @llvm.riscv.cv.mac.macsN
+int32_t test_mac_macsN(uint32_t x, uint32_t y, int32_t z) {
+    return __riscv_cv_mac_macsN(x, y, z, 0);
+}
+
+// CHECK-LABEL: @test_mac_machhsN
+// CHECK: @llvm.riscv.cv.mac.machhsN
+int32_t test_mac_machhsN(uint32_t x, uint32_t y, int32_t z) {
+    return __riscv_cv_mac_machhsN(x, y, z, 0);
+}
+
+// CHECK-LABEL: @test_mac_macuRN
+// CHECK: @llvm.riscv.cv.mac.macuRN
+uint32_t test_mac_macuRN(uint32_t x, uint32_t y, uint32_t z) {
+    return __riscv_cv_mac_macuRN(x, y, z, 0);
+}
+
+// CHECK-LABEL: @test_mac_machhuRN
+// CHECK: @llvm.riscv.cv.mac.machhuRN
+uint32_t test_mac_machhuRN(uint32_t x, uint32_t y, uint32_t z) {
+    return __riscv_cv_mac_machhuRN(x, y, z, 0);
+}
+
+// CHECK-LABEL: @test_mac_macsRN
+// CHECK: @llvm.riscv.cv.mac.macsRN
+int32_t test_mac_macsRN(uint32_t x, uint32_t y, int32_t z) {
+    return __riscv_cv_mac_macsRN(x, y, z, 0);
+}
+
+// CHECK-LABEL: @test_mac_machhsRN
+// CHECK: @llvm.riscv.cv.mac.machhsRN
+int32_t test_mac_machhsRN(uint32_t x, uint32_t y, int32_t z) {
+    return __riscv_cv_mac_machhsRN(x, y, z, 0);
+}


### PR DESCRIPTION
This patch adds the C API header file for the xcvmac Clang builtins.
It also adds the CodeGen test that checks that the wrapper functions defined in the header turn into the right LLVM instrinsic when called.
Finally the patch adds the cmake support for the header file. This needs to follow the analogous patch for the xcvbitmanip builtins as that one includes the basic cmake support to add all the headers.

