### PR TITLE
[RISCV][CV-SIMD] Fix the immediate type in the shuffle pseudo expansion.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -365,7 +365,7 @@ bool RISCVExpandPseudo::expandCoreVShuffle(MachineBasicBlock &MBB,
   const MCInstrDesc &Desc = TII->get(Opcodes[Imm >> 6]);
   BuildMI(MBB, MBBI, DL, Desc, DstReg)
       .addReg(SrcReg)
-      .addImm(APInt(6, Imm, true).getSExtValue());
+      .addImm(APInt(6, Imm, false).getZExtValue());
   MBBI->eraseFromParent();
   return true;
 }


### PR DESCRIPTION
The immediate operand of the 'sci' variant of the shuffle instructions of the xcvsimd extension is always zero-extended.
This commit fixes the expansion of the pseudo shuffle instruction by adding an unsigned immediate parameter (hence zero-extended) rather then a signed one as it was before.

This patch is a reboot of the previous PR #87 

It is just a cleaner approach than a merge commit. The original change is good and copied untouched here.