### PR TITLE
Use target independent builtins

### DIFF
--- a/clang/include/clang/Basic/BuiltinsRISCVCOREV.def
+++ b/clang/include/clang/Basic/BuiltinsRISCVCOREV.def
@@ -174,7 +174,6 @@ TARGET_BUILTIN(bitmanip_ff1, "UZcUZi", "nc", "xcvbitmanip")
 TARGET_BUILTIN(bitmanip_fl1, "UZcUZi", "nc", "xcvbitmanip")
 TARGET_BUILTIN(bitmanip_clb, "UZcUZi", "nc", "xcvbitmanip")
 TARGET_BUILTIN(bitmanip_cnt, "UZcUZi", "nc", "xcvbitmanip")
-TARGET_BUILTIN(bitmanip_ror, "UZiUZiUZi", "nc", "xcvbitmanip")
 TARGET_BUILTIN(bitmanip_bitrev, "UZiUZiIUcIUc", "nc", "xcvbitmanip")
 
 TARGET_BUILTIN(mac_mac, "UZiUZiUZiUZi", "nc", "xcvmac")

--- a/clang/lib/Headers/riscv_corev_bitmanip.h
+++ b/clang/lib/Headers/riscv_corev_bitmanip.h
@@ -58,7 +58,7 @@ static __inline__ uint8_t __DEFAULT_FN_ATTRS __riscv_cv_bitmanip_cnt(unsigned lo
 }
 
 static __inline__ unsigned long __DEFAULT_FN_ATTRS __riscv_cv_bitmanip_ror(unsigned long a, unsigned long b) {
-  return __builtin_riscv_cv_bitmanip_ror(a, b);
+  return __builtin_rotateright32(a, b);
 }
 
 #define __riscv_cv_bitmanip_bitrev(rs1, PTS, RADIX) \

--- a/clang/test/CodeGen/RISCV/corev-intrinsics/bitmanip-c-api.c
+++ b/clang/test/CodeGen/RISCV/corev-intrinsics/bitmanip-c-api.c
@@ -90,7 +90,7 @@ uint32_t test_cnt(uint32_t a) {
 }
 
 // CHECK-LABEL: @test_ror
-// CHECK: @llvm.riscv.cv.bitmanip.ror
+// CHECK: @llvm.fshr.i32
 uint32_t test_ror(uint32_t a, uint32_t b) {
     return __riscv_cv_bitmanip_ror(a, b);
 }

--- a/clang/test/CodeGen/RISCV/corev-intrinsics/bitmanip.c
+++ b/clang/test/CodeGen/RISCV/corev-intrinsics/bitmanip.c
@@ -199,21 +199,6 @@ uint32_t test_cnt(uint32_t a) {
     return __builtin_riscv_cv_bitmanip_cnt(a);
 }
 
-// CHECK-LABEL: @test_ror(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[A_ADDR:%.*]] = alloca i32, align 4
-// CHECK-NEXT:    [[B_ADDR:%.*]] = alloca i32, align 4
-// CHECK-NEXT:    store i32 [[A:%.*]], ptr [[A_ADDR]], align 4
-// CHECK-NEXT:    store i32 [[B:%.*]], ptr [[B_ADDR]], align 4
-// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[A_ADDR]], align 4
-// CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[B_ADDR]], align 4
-// CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.cv.bitmanip.ror(i32 [[TMP0]], i32 [[TMP1]])
-// CHECK-NEXT:    ret i32 [[TMP2]]
-//
-uint32_t test_ror(uint32_t a, uint32_t b) {
-    return __builtin_riscv_cv_bitmanip_ror(a, b);
-}
-
 // CHECK-LABEL: @test_bitrev(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_ADDR:%.*]] = alloca i32, align 4

--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -1730,8 +1730,6 @@ def int_riscv_cv_bitmanip_fl1 : ScalarCoreVBitManipGprIntrinsic;
 def int_riscv_cv_bitmanip_clb : ScalarCoreVBitManipGprIntrinsic;
 def int_riscv_cv_bitmanip_cnt : ScalarCoreVBitManipGprIntrinsic;
 
-def int_riscv_cv_bitmanip_ror : ScalarCoreVBitManipGprGprIntrinsic;
-
 def int_riscv_cv_bitmanip_bitrev
   : Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
               [IntrNoMem, IntrWillReturn, IntrSpeculatable, ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -272,13 +272,15 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
   setOperationAction({ISD::SHL_PARTS, ISD::SRL_PARTS, ISD::SRA_PARTS}, XLenVT,
                      Custom);
 
-  if (Subtarget.hasStdExtZbb() || Subtarget.hasStdExtZbkb()) {
-    if (Subtarget.is64Bit())
-      setOperationAction({ISD::ROTL, ISD::ROTR}, MVT::i32, Custom);
-  } else {
-    setOperationAction({ISD::ROTL, ISD::ROTR}, XLenVT, Expand);
+  
+  if (!Subtarget.hasExtXcvbitmanip()) {
+    if (Subtarget.hasStdExtZbb() || Subtarget.hasStdExtZbkb()) {
+      if (Subtarget.is64Bit())
+        setOperationAction({ISD::ROTL, ISD::ROTR}, MVT::i32, Custom);
+    } else {
+      setOperationAction({ISD::ROTL, ISD::ROTR}, XLenVT, Expand);
+    }
   }
-
   // With Zbb we have an XLen rev8 instruction, but not GREVI. So we'll
   // pattern match it directly in isel.
   setOperationAction(ISD::BSWAP, XLenVT,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -1222,8 +1222,10 @@ let Predicates = [HasExtXcvbitmanip, IsRV32] in {
   def : PatGpr<int_riscv_cv_bitmanip_clb, CV_CLB>;
   def : PatGpr<int_riscv_cv_bitmanip_cnt, CV_CNT>;
 
-  def : PatGprGpr<int_riscv_cv_bitmanip_ror, CV_ROR>;
-
+  //def : PatGprGpr<int_riscv_cv_bitmanip_ror, CV_ROR>;
+  def : Pat<(rotr i32:$rs1, i32:$rs2),
+            (CV_ROR GPR:$rs1, GPR:$rs2)>;
+  
   def : Pat<(int_riscv_cv_bitmanip_bitrev GPR:$rs1, cv_tuimm5:$pts, cv_tuimm2:$radix),
             (CV_BITREV GPR:$rs1, cv_tuimm2:$radix, cv_tuimm5:$pts)>;
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoCOREV.td
@@ -1222,9 +1222,7 @@ let Predicates = [HasExtXcvbitmanip, IsRV32] in {
   def : PatGpr<int_riscv_cv_bitmanip_clb, CV_CLB>;
   def : PatGpr<int_riscv_cv_bitmanip_cnt, CV_CNT>;
 
-  //def : PatGprGpr<int_riscv_cv_bitmanip_ror, CV_ROR>;
-  def : Pat<(rotr i32:$rs1, i32:$rs2),
-            (CV_ROR GPR:$rs1, GPR:$rs2)>;
+  def : PatGprGpr<rotr, CV_ROR>;
   
   def : Pat<(int_riscv_cv_bitmanip_bitrev GPR:$rs1, cv_tuimm5:$pts, cv_tuimm2:$radix),
             (CV_BITREV GPR:$rs1, cv_tuimm2:$radix, cv_tuimm5:$pts)>;

--- a/llvm/test/CodeGen/RISCV/corev/bitmanip.ll
+++ b/llvm/test/CodeGen/RISCV/corev/bitmanip.ll
@@ -155,14 +155,14 @@ define i32 @test.cv.cnt(i32 %a) {
   ret i32 %1
 }
 
-declare i32 @llvm.riscv.cv.bitmanip.ror(i32, i32)
+declare i32 @llvm.fshr.i32(i32, i32, i32)
 
 define i32 @test.cv.ror(i32 %a, i32 %b) {
 ; CHECK-LABEL: test.cv.ror:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    cv.ror a0, a0, a1
 ; CHECK-NEXT:    ret
-  %1 = call i32 @llvm.riscv.cv.bitmanip.ror(i32 %a, i32 %b)
+  %1 = call i32 @llvm.fshr.i32(i32 %a, i32 %a , i32 %b)
   ret i32 %1
 }
 


### PR DESCRIPTION
This PR is not ready for the merge because I haven't covered all possible corev bitmanip builtins yet. For now, only the **__builtin_riscv_cv_bitmanip_ror** has been replaced with the target independent **__builtin_rotateright32**.
I am creating a PR so that concerned developers can review the code that has been pushed so far and provide their valuable feedback.